### PR TITLE
Configurable example solution patern

### DIFF
--- a/configlet/config.go
+++ b/configlet/config.go
@@ -9,16 +9,17 @@ import (
 
 // Config is an Exercism track configuration.
 type Config struct {
-	path       string
-	Slug       string
-	Language   string
-	Active     bool
-	Repository string
-	Problems   []string
-	Exercises  []Exercise
-	Ignored    []string
-	Deprecated []string
-	Foregone   []string
+	path            string
+	Slug            string
+	Language        string
+	Active          bool
+	Repository      string
+	Problems        []string
+	Exercises       []Exercise
+	Ignored         []string
+	Deprecated      []string
+	Foregone        []string
+	SolutionPattern string `json:"solution_pattern"`
 }
 
 type Exercise struct {
@@ -29,7 +30,7 @@ type Exercise struct {
 
 // Load loads an Exercism track configuration.
 func Load(file string) (Config, error) {
-	c := Config{}
+	c := NewConfig()
 
 	bytes, err := ioutil.ReadFile(file)
 	if err != nil {
@@ -39,7 +40,15 @@ func Load(file string) (Config, error) {
 	if err != nil {
 		return c, fmt.Errorf("Unable to parse config: %s -- %s", file, err.Error())
 	}
+
 	return c, nil
+}
+
+// Create new Config with optional defaults set.
+// Currently the only optional value is SolutionPattern which is used by Track
+// to work out if a problem has a provided solution file.
+func NewConfig() Config {
+	return Config{SolutionPattern: "[Ee]xample"}
 }
 
 func (c Config) Slugs() []string {

--- a/configlet/config_test.go
+++ b/configlet/config_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewConfigHasDefaultSolutionPattern(t *testing.T) {
+	c := NewConfig()
+	expected := "[Ee]xample"
+	assert.Equal(t, expected, c.SolutionPattern)
+}
+
 func TestBrokenConfig(t *testing.T) {
 	if _, err := Load("./fixtures/broken.json"); err == nil {
 		t.Errorf("Expected Load() to complain that it couldn't parse the JSON")

--- a/configlet/fixtures/track/config.json
+++ b/configlet/fixtures/track/config.json
@@ -3,6 +3,7 @@
   "language": "Gemstones",
   "repository": "https://github.com/exercism/xgemstones",
   "active": true,
+  "solution_pattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.rb",
   "problems": [
     "amethyst",
     "beryl",

--- a/configlet/fixtures/track/config.json
+++ b/configlet/fixtures/track/config.json
@@ -8,7 +8,8 @@
     "beryl",
     "crystal",
     "melanite",
-    "sapphire"
+    "sapphire",
+    "rhodolite"
   ],
   "deprecated": [
     "opal",

--- a/configlet/fixtures/track/rhodolite/.meta/solutions/rhodolite.rb
+++ b/configlet/fixtures/track/rhodolite/.meta/solutions/rhodolite.rb
@@ -1,0 +1,1 @@
+puts "I'm not Ruby"

--- a/configlet/track.go
+++ b/configlet/track.go
@@ -220,7 +220,7 @@ func (t Track) ProblemsLackingExample() ([]string, error) {
 		if err != nil {
 			return issues, err
 		}
-		found, err := hasExampleFile(files)
+		found, err := t.hasExampleFile(files)
 		if !found {
 			issues = append(issues, problem)
 		}
@@ -301,11 +301,17 @@ func (t Track) configFile() string {
 	return fmt.Sprintf("%s/config.json", t.path)
 }
 
-func hasExampleFile(files []string) (bool, error) {
-	r, err := regexp.Compile(`[Ee]xample`)
+func (t Track) hasExampleFile(files []string) (bool, error) {
+	c, err := t.Config()
 	if err != nil {
 		return false, err
 	}
+
+	r, err := regexp.Compile(c.SolutionPattern)
+	if err != nil {
+		return false, err
+	}
+
 	for _, file := range files {
 		matches := r.Find([]byte(file))
 		if len(matches) > 0 {

--- a/configlet/track_test.go
+++ b/configlet/track_test.go
@@ -20,6 +20,7 @@ func TestNewTrack(t *testing.T) {
 		"fixtures/track/exercises/melanite",
 		"fixtures/track/ignored",
 		"fixtures/track/sapphire",
+		"fixtures/track/rhodolite",
 	}
 
 	var paths []string
@@ -55,6 +56,7 @@ func TestTrackDirs(t *testing.T) {
 		"ignored",
 		"diamond",
 		"melanite",
+		"rhodolite",
 		"sapphire",
 	}
 
@@ -84,6 +86,7 @@ func TestTrackProblems(t *testing.T) {
 		"crystal",
 		"melanite",
 		"sapphire",
+		"rhodolite",
 	}
 
 	if len(problems) != len(expected) {
@@ -119,6 +122,7 @@ func TestSlugs(t *testing.T) {
 		"opal",
 		"pearl",
 		"sapphire",
+		"rhodolite",
 	}
 
 	if len(slugs) != len(expected) {


### PR DESCRIPTION
Fixes: #12 

Previously the pattern used to check if an example solution was present for a file was hardcoded to `[Ee]xample`.

Since support was added for ignored `.meta` directory it is no longer necessary for a solution filename to contain `example` to avoid being served to the student.

This patch adds support for configuring the pattern used to detect the presence of an example solution.

It is set via the optional key `solution_pattern` in the track's `config.json` file. The value is a string which is used to create a regular expression.

If the key is not present the default value of `[Ee]xample` will be used.

Edit: fixed json key name