### PR TITLE
Delete unused variable

### DIFF
--- a/track/config.go
+++ b/track/config.go
@@ -2,12 +2,9 @@ package track
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
-
-var errInvalidConfig = errors.New("invalid config file - try jsonlint.com")
 
 // Config is an Exercism track configuration.
 type Config struct {


### PR DESCRIPTION
The error message needs dynamic data (path, actual error), so this variable never ended up
getting used.