### PR TITLE
Provide a MixedCase version of the problem spec name

### DIFF
--- a/track/problem_specification.go
+++ b/track/problem_specification.go
@@ -57,6 +57,11 @@ func (spec *ProblemSpecification) Name() string {
 	return strings.Title(strings.Join(strings.Split(spec.Slug, "-"), " "))
 }
 
+// MixedCaseName returns the name with all spaces removed.
+func (spec *ProblemSpecification) MixedCaseName() string {
+	return strings.Replace(spec.Name(), " ", "", -1)
+}
+
 // Credits are a markdown-formatted version of the source of the exercise.
 func (spec *ProblemSpecification) Credits() string {
 	if spec.SourceURL == "" {

--- a/track/problem_specification_test.go
+++ b/track/problem_specification_test.go
@@ -64,26 +64,31 @@ func TestMissingProblemSpecification(t *testing.T) {
 
 func TestProblemSpecificationName(t *testing.T) {
 	tests := []struct {
-		slug string
-		name string
+		slug  string
+		name  string
+		mixed string
 	}{
 		{
-			slug: "apple",
-			name: "Apple",
+			slug:  "apple",
+			name:  "Apple",
+			mixed: "Apple",
 		},
 		{
-			slug: "apple-pie",
-			name: "Apple Pie",
+			slug:  "apple-pie",
+			name:  "Apple Pie",
+			mixed: "ApplePie",
 		},
 		{
-			slug: "1-apple-per-day",
-			name: "1 Apple Per Day",
+			slug:  "1-apple-per-day",
+			name:  "1 Apple Per Day",
+			mixed: "1ApplePerDay",
 		},
 	}
 
 	for _, test := range tests {
 		spec := ProblemSpecification{Slug: test.slug}
 		assert.Equal(t, test.name, spec.Name())
+		assert.Equal(t, test.mixed, spec.MixedCaseName())
 	}
 }
 


### PR DESCRIPTION
This will let us use that in generated READMEs for languages who name their test files in mixed case.

E.g. here: https://github.com/exercism/groovy/tree/master/exercises/difference-of-squares

