### PR TITLE
Add check for missing problem-specifications directory

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,18 @@
   version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  revision = "83588e72410abfbe4df460eeb6f30841ae47d4c4"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -52,6 +64,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9c9b4be2565453cbd659554e7905e2a9a413f5d1de43914204330564f9cbc093"
+  inputs-digest = "86718b7614f4254ac2e62b1cd50e8886d1b062122f49da8fca8a0a76aef80884"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/fixtures/problem-specifications/exercises/fake/description.md
+++ b/fixtures/problem-specifications/exercises/fake/description.md
@@ -1,0 +1,1 @@
+This is fake.

--- a/fixtures/problem-specifications/exercises/fake/metadata.yml
+++ b/fixtures/problem-specifications/exercises/fake/metadata.yml
@@ -1,0 +1,4 @@
+---
+blurb: "Fake."
+source: "The internet."
+source_url: "http://example.com"

--- a/track/exercise_readme.go
+++ b/track/exercise_readme.go
@@ -40,15 +40,15 @@ func NewExerciseReadme(root, trackID, slug string) (ExerciseReadme, error) {
 		dir:      filepath.Join(root, trackID, dirExercises, slug),
 	}
 
+	spec, err := NewProblemSpecification(root, trackID, slug)
+	if err != nil {
+		return readme, err
+	}
+	readme.Spec = spec
+
 	if err := readme.readTemplate(); err != nil {
 		return readme, err
 	}
-
-	spec, err := NewProblemSpecification(root, trackID, slug)
-	if err != nil {
-		spec = &ProblemSpecification{}
-	}
-	readme.Spec = spec
 
 	if err := readme.readHints(); err != nil {
 		return readme, err

--- a/track/exercise_readme_test.go
+++ b/track/exercise_readme_test.go
@@ -51,6 +51,7 @@ func TestExerciseReadmeTrackInsertDeprecation(t *testing.T) {
 		{"inserts-old", "deprecated insert\n"},
 	}
 
+	ProblemSpecificationsPath = filepath.FromSlash("../fixtures/problem-specifications")
 	for _, test := range tests {
 		readme, err := NewExerciseReadme(root, test.trackID, "fake")
 		assert.NoError(t, err)
@@ -69,6 +70,7 @@ func TestExerciseReadmeHintsDeprecation(t *testing.T) {
 		{"hints-old", "deprecated hints\n"},
 	}
 
+	ProblemSpecificationsPath = filepath.FromSlash("../fixtures/problem-specifications")
 	for _, test := range tests {
 		readme, err := NewExerciseReadme(root, test.trackID, "fake")
 		assert.NoError(t, err)

--- a/track/problem_specification.go
+++ b/track/problem_specification.go
@@ -10,8 +10,10 @@ import (
 )
 
 const (
-	filenameDescription = "description.md"
-	filenameMetadata    = "metadata.yml"
+	// ProblemSpecificationsDir is the default name of the cloned problem-specifications repository.
+	ProblemSpecificationsDir = "problem-specifications"
+	filenameDescription      = "description.md"
+	filenameMetadata         = "metadata.yml"
 )
 
 var (
@@ -94,7 +96,7 @@ func (spec *ProblemSpecification) sharedPath() string {
 	if ProblemSpecificationsPath != "" {
 		return filepath.Join(ProblemSpecificationsPath, "exercises", spec.Slug)
 	}
-	return filepath.Join(spec.root, "problem-specifications", "exercises", spec.Slug)
+	return filepath.Join(spec.root, ProblemSpecificationsDir, "exercises", spec.Slug)
 }
 
 func (spec *ProblemSpecification) customPath() string {


### PR DESCRIPTION
Readme generation depends on the existence of the problem-specifications repository. This change fixes an issue where executing a readme generation with an zero-value ProblemSpecification results in a incomplete Readme.md file. 

The configlet command will now print an error message if it is unable to load the problem-specifications repository.

Closes exercism/configlet#27