### PR TITLE
Add verbose flag to fmt.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,7 +29,7 @@
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "b26b538f693051ac6518e65672de3144ce3fbedc"
+  revision = "cb731b898346822cc0c225c28550a8a29d93c732"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -47,11 +47,11 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "25c4ec802a7d637f88d584ab26798e94ad14c13b"
+  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9c9b4be2565453cbd659554e7905e2a9a413f5d1de43914204330564f9cbc093"
+  inputs-digest = "6f58fa0c4ebe7a408c17780d5b18c5d7ca958646172dc0f6e70c38468cacf8aa"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -17,21 +17,19 @@ var (
 var (
 	// generateCmd represents the generate command
 	generateCmd = &cobra.Command{
-		Use:   "generate",
+		Use:   "generate <path/to/track>",
 		Short: "Generate exercise READMEs for an Exercism language track",
-		Long: `Generate READMEs for Exercism exercises based on contents of
-a number of different files.`,
-		Run: generate,
+		Long:  `Generate READMEs for Exercism exercises based on the contents of various files.`,
+		Example: `  configlet generate <path/to/track> --only hello-world
+
+  configlet generate <path/to/track> --spec-path <path/to/problem-specifications>
+`,
+		Run:  generate,
+		Args: cobra.MinimumNArgs(1),
 	}
-	generateUsageText = "USAGE: configlet generate <path/to/track>\n"
 )
 
 func generate(cmd *cobra.Command, args []string) {
-	if len(args) == 0 {
-		generateUsageFunc(cmd)
-		os.Exit(1)
-	}
-
 	path, err := filepath.Abs(filepath.FromSlash(args[0]))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, err.Error())
@@ -68,14 +66,8 @@ func generate(cmd *cobra.Command, args []string) {
 	}
 }
 
-func generateUsageFunc(cmd *cobra.Command) error {
-	fmt.Fprintf(os.Stderr, generateUsageText)
-	return nil
-}
-
 func init() {
 	RootCmd.AddCommand(generateCmd)
-	generateCmd.SetUsageFunc(generateUsageFunc)
 	generateCmd.Flags().StringVarP(&genSlug, "only", "o", "", "Generate READMEs for just the exercise specified (by the slug).")
 	generateCmd.Flags().StringVarP(&specPath, "spec-path", "p", "", "The location of the problem-specifications directory.")
 }


### PR DESCRIPTION
With this the default output if there are changes will only be
the filenames where changes have occured. To include the actual
diff in the output, the `verbose` flag can be used.