### PR TITLE
Add UUID validation across exercises and tracks to lint command

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,12 +1,21 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/exercism/configlet/track"
 	"github.com/spf13/cobra"
 )
+
+// UUIDValidationURL is the endpoint to Exercism's UUID validation service.
+var UUIDValidationURL = "http://exercism.io/api/v1/uuids"
+
+// disableHTTPChecks flag skips HTTP based checks when passed.
+var disableHTTPChecks bool
 
 // lintCmd defines the lint command.
 var lintCmd = &cobra.Command{
@@ -78,16 +87,24 @@ func lintTrack(path string) bool {
 			check: duplicateSlugs,
 			msg:   "-> The exercise '%v' was found in multiple (conflicting) categories in config.json.\n",
 		},
+		{
+			check: duplicateUUID,
+			msg:   "-> The following UUID occurs multiple times. Each exercise UUID must be unique.\n%v\n",
+		},
+		{
+			check: duplicateTrackUUID,
+			msg:   "-> The following UUID was found in multiple Exercism tracks. Each exercise UUID must be unique across tracks.\n%v\n",
+		},
 	}
 
 	hasErrors := false
 	for _, configError := range configErrors {
-		slugs := configError.check(t)
+		failedItems := configError.check(t)
 
-		if len(slugs) > 0 {
+		if len(failedItems) > 0 {
 			hasErrors = true
-			for _, slug := range slugs {
-				fmt.Printf(configError.msg, slug)
+			for _, item := range failedItems {
+				fmt.Printf(configError.msg, item)
 			}
 		}
 	}
@@ -228,6 +245,73 @@ func duplicateSlugs(t track.Track) []string {
 	return slugs
 }
 
+func duplicateUUID(t track.Track) []string {
+	uuids := []string{}
+	seen := map[string]bool{}
+	for _, exercise := range t.Config.Exercises {
+		if exercise.UUID == "" {
+			continue
+		}
+
+		if seen[exercise.UUID] {
+			uuids = append(uuids, exercise.UUID)
+		}
+
+		seen[exercise.UUID] = true
+	}
+
+	return uuids
+}
+
+func duplicateTrackUUID(t track.Track) []string {
+	if disableHTTPChecks {
+		return []string{}
+	}
+
+	// Build up set of uuids to validate.
+	uuids := []string{}
+	for _, exercise := range t.Config.Exercises {
+		if exercise.UUID == "" {
+			continue
+		}
+		uuids = append(uuids, exercise.UUID)
+	}
+
+	payload := struct {
+		TrackID string   `json:"track_id"`
+		UUIDs   []string `json:"uuids"`
+	}{
+		TrackID: t.ID,
+		UUIDs:   uuids,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "-> %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	resp, err := http.Post(UUIDValidationURL, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "-> %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusConflict {
+		result := struct{ UUIDs []string }{}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			fmt.Fprintf(os.Stderr, "-> %s\n", err.Error())
+			os.Exit(1)
+		}
+
+		return result.UUIDs
+	}
+
+	return []string{}
+}
+
 func init() {
 	RootCmd.AddCommand(lintCmd)
+	lintCmd.Flags().BoolVar(&disableHTTPChecks, "no-http", false, "Disable remote HTTP-based linting.")
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -67,6 +67,10 @@ func lintTrack(path string) bool {
 			msg:   "-> The implementation for '%v' is missing a test suite.\n",
 		},
 		{
+			check: missingUUID,
+			msg:   "-> The exercise '%v' was found in config.json, but does not have a UUID.\n",
+		},
+		{
 			check: foregoneViolations,
 			msg:   "-> An implementation for '%v' was found, but config.json specifies that it should be foregone (not implemented).\n",
 		},
@@ -173,6 +177,17 @@ func missingTestSuite(t track.Track) []string {
 			slugs = append(slugs, slug)
 		}
 	}
+	return slugs
+}
+
+func missingUUID(t track.Track) []string {
+	slugs := []string{}
+	for _, exercise := range t.Config.Exercises {
+		if exercise.UUID == "" {
+			slugs = append(slugs, exercise.Slug)
+		}
+	}
+
 	return slugs
 }
 

--- a/cmd/lint_example_test.go
+++ b/cmd/lint_example_test.go
@@ -3,6 +3,10 @@ package cmd
 import "path/filepath"
 
 func ExampleLint() {
+	saved := disableHTTPChecks
+	disableHTTPChecks = true
+	defer func() { disableHTTPChecks = saved }()
+
 	lintTrack(filepath.FromSlash("../fixtures/numbers"))
 	// Output:
 	// -> An exercise with slug 'bajillion' is referenced in config.json, but no implementation was found.
@@ -13,6 +17,10 @@ func ExampleLint() {
 }
 
 func ExampleLintMaintainers() {
+	saved := disableHTTPChecks
+	disableHTTPChecks = true
+	defer func() { disableHTTPChecks = saved }()
+
 	lintTrack(filepath.FromSlash("../fixtures/broken-maintainers"))
 	// Output:
 	// -> invalid config ../fixtures/broken-maintainers/config/maintainers.json -- invalid character '}' looking for beginning of object key string

--- a/cmd/lint_example_test.go
+++ b/cmd/lint_example_test.go
@@ -8,6 +8,7 @@ func ExampleLint() {
 	// -> An exercise with slug 'bajillion' is referenced in config.json, but no implementation was found.
 	// -> The implementation for 'three' is missing an example solution.
 	// -> The implementation for 'two' is missing a test suite.
+	// -> The exercise 'one' was found in config.json, but does not have a UUID.
 	// -> An implementation for 'zero' was found, but config.json specifies that it should be foregone (not implemented).
 }
 

--- a/fixtures/numbers/config.json
+++ b/fixtures/numbers/config.json
@@ -11,20 +11,20 @@
       "difficulty": 1
     },
     {
-      "uuid": "3d0343ec-0658-7a80-9d1d-d48bed03cc2397805f5",
+      "uuid": "bbb",
       "slug": "two",
       "deprecated": true,
       "topics": [],
       "difficulty": 1
     },
     {
-      "uuid": "cff27211-0179-4a80-e456-f8ed3b8194a2b7480cb",
+      "uuid": "ccc",
       "slug": "three",
       "topics": [],
       "difficulty": 1
     },
     {
-      "uuid": "5c37ad59-07b3-1c80-cb0c-44d06708095a02a6760",
+      "uuid": "ddd",
       "slug": "bajillion",
       "topics": [],
       "difficulty": 1

--- a/fixtures/numbers/config.json
+++ b/fixtures/numbers/config.json
@@ -11,19 +11,24 @@
       "difficulty": 1
     },
     {
+      "uuid": "3d0343ec-0658-7a80-9d1d-d48bed03cc2397805f5",
       "slug": "two",
       "deprecated": true,
       "topics": [],
       "difficulty": 1
     },
     {
+      "uuid": "cff27211-0179-4a80-e456-f8ed3b8194a2b7480cb",
+      "slug": "three",
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "uuid": "5c37ad59-07b3-1c80-cb0c-44d06708095a02a6760",
       "slug": "bajillion",
       "topics": [],
       "difficulty": 1
     }
-  ],
-  "deprecated": [
-    "three"
   ],
   "foregone": [
     "zero"

--- a/track/exercise_metadata.go
+++ b/track/exercise_metadata.go
@@ -4,6 +4,7 @@ package track
 // It's listed in the config in the order that the exercise will be
 // delivered by the API.
 type ExerciseMetadata struct {
+	UUID         string
 	Slug         string
 	Difficulty   int
 	Topics       []string

--- a/track/track.go
+++ b/track/track.go
@@ -7,10 +7,11 @@ import (
 
 // Track is a collection of Exercism exercises for a programming language.
 type Track struct {
-	path             string
+	ID               string
 	Config           Config
 	MaintainerConfig MaintainerConfig
 	Exercises        []Exercise
+	path             string
 }
 
 // New loads a track.
@@ -18,6 +19,7 @@ func New(path string) (Track, error) {
 	track := Track{
 		path: filepath.FromSlash(path),
 	}
+	track.ID = filepath.Base(path)
 
 	c, err := NewConfig(filepath.Join(path, "config.json"))
 	if err != nil {

--- a/track/track_test.go
+++ b/track/track_test.go
@@ -10,6 +10,7 @@ func TestNewTrack(t *testing.T) {
 	track, err := New("../fixtures/numbers")
 	assert.NoError(t, err)
 
+	assert.Equal(t, "numbers", track.ID)
 	assert.Equal(t, "Numbers", track.Config.Language)
 
 	slugs := map[string]bool{


### PR DESCRIPTION
This is a simple check that validates exercises UUIDs against the metadata defined within the track's config.json.

- [x] Fix fixtures now that UUID is required. 
- [x] Review logic for API to check UUIDs across the wire.

closes #28, #29, #30