### PR TITLE
Replace calls to Fprintf with Fprintln

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -40,7 +40,7 @@ func generateExampleText() string {
 func runGenerate(cmd *cobra.Command, args []string) {
 	path, err := filepath.Abs(filepath.FromSlash(args[0]))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 	root := filepath.Dir(path)
@@ -62,7 +62,7 @@ func runGenerate(cmd *cobra.Command, args []string) {
 	} else {
 		track, err := track.New(path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 		exercises = track.Exercises
@@ -82,7 +82,7 @@ func runGenerate(cmd *cobra.Command, args []string) {
 	}
 
 	if err := errs.ErrorOrNil(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,7 +19,7 @@ var versionCmd = &cobra.Command{
 }
 
 func runVersion(cmd *cobra.Command, args []string) {
-	fmt.Printf("%s v%s\n", binaryName, Version)
+	fmt.Printf("%s version %s\n", binaryName, Version)
 }
 
 func init() {


### PR DESCRIPTION
The use of fmt.Fprintf should be reserved for outputting messages that require string interpolation or formatting that can not be achieved with fmt.Fprintln.

This change also includes a minor tweak to the version command's output. 