### PR TITLE
Ammendments to commands

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -29,7 +29,7 @@ It also normalizes and alphabetizes the exercise topics in the config.json file.
 `,
 	Example: fmt.Sprintf("  %s fmt %s --verbose", binaryName, pathExample),
 	Run:     runFmt,
-	Args:    cobra.MinimumNArgs(1),
+	Args:    cobra.ExactArgs(1),
 }
 
 // formatter applies additional formatting to unmarshalled JSON files.

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -55,12 +55,12 @@ func runFmt(cmd *cobra.Command, args []string) {
 
 	for _, f := range fs {
 		if _, err := os.Stat(f.path); os.IsNotExist(err) {
-			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Fprintf(os.Stderr, "-> path not found: %s\n", f.path)
 			os.Exit(1)
 		}
 		diff, formatted, err := formatFile(f.path, f.formatter)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Fprintf(os.Stderr, "-> %s", err.Error())
 			continue
 		}
 		if diff == "" {
@@ -68,17 +68,17 @@ func runFmt(cmd *cobra.Command, args []string) {
 		}
 		err = ioutil.WriteFile(f.path, formatted, os.FileMode(0644))
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Fprintf(os.Stderr, "-> %s", err.Error())
 			continue
 		}
 		if fmtVerbose {
-			fmt.Printf("%s\n\n%s\n", f.path, diff)
+			fmt.Printf("-> %s\n\n%s\n", f.path, diff)
 		}
 		changes += fmt.Sprintf("%s\n", f.path)
 	}
 
 	if changes != "" {
-		fmt.Printf("Changes made to:\n%s", changes)
+		fmt.Printf("-> changes made to:\n%s", changes)
 	}
 	return
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -24,7 +24,7 @@ var (
 		Long:    `Generate READMEs for Exercism exercises based on the contents of various files.`,
 		Example: generateExampleText(),
 		Run:     runGenerate,
-		Args:    cobra.MinimumNArgs(1),
+		Args:    cobra.ExactArgs(1),
 	}
 )
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -40,7 +40,7 @@ func generateExampleText() string {
 func runGenerate(cmd *cobra.Command, args []string) {
 	path, err := filepath.Abs(filepath.FromSlash(args[0]))
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		fmt.Printf("-> %s\n", err)
 		os.Exit(1)
 	}
 	root := filepath.Dir(path)
@@ -52,7 +52,7 @@ func runGenerate(cmd *cobra.Command, args []string) {
 	}
 
 	if _, err := os.Stat(track.ProblemSpecificationsPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "path not found: %s\n", track.ProblemSpecificationsPath)
+		fmt.Fprintf(os.Stderr, "-> path not found: %s\n", track.ProblemSpecificationsPath)
 		os.Exit(1)
 	}
 
@@ -62,7 +62,7 @@ func runGenerate(cmd *cobra.Command, args []string) {
 	} else {
 		track, err := track.New(path)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Fprintf(os.Stderr, "-> %s", err.Error())
 			os.Exit(1)
 		}
 		exercises = track.Exercises
@@ -82,7 +82,7 @@ func runGenerate(cmd *cobra.Command, args []string) {
 	}
 
 	if err := errs.ErrorOrNil(); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		fmt.Fprintf(os.Stderr, "-> %s", err.Error())
 		os.Exit(1)
 	}
 

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -37,6 +37,10 @@ func runLint(cmd *cobra.Command, args []string) {
 }
 
 func lintTrack(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "-> path not found: %s\n", path)
+		os.Exit(1)
+	}
 	t, err := track.New(path)
 	if err != nil {
 		fmt.Printf("-> %s\n", err)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -21,7 +21,7 @@ It also checks that the exercises defined in the config.json file are complete.
 `,
 	Example: fmt.Sprintf("  %s lint %s", binaryName, pathExample),
 	Run:     runLint,
-	Args:    cobra.MinimumNArgs(1),
+	Args:    cobra.ExactArgs(1),
 }
 
 func runLint(cmd *cobra.Command, args []string) {

--- a/cmd/uuid.go
+++ b/cmd/uuid.go
@@ -20,7 +20,7 @@ UUIDs, even though they are based on the same problem specification.
 `,
 	Example: fmt.Sprintf("  %s uuid", binaryName),
 	Run:     runUUID,
-	Args:    cobra.MaximumNArgs(0),
+	Args:    cobra.ExactArgs(0),
 }
 
 // runUUID prints out a unique exercise UUID

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,7 @@ var versionCmd = &cobra.Command{
 	Long:    "Output the current version of the tool",
 	Example: fmt.Sprintf("  %s version", binaryName),
 	Run:     runVersion,
+	Args:    cobra.ExactArgs(0),
 }
 
 func runVersion(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Somehow I missed `cobra.ExactArgs` and so have changed
`cobra.MinimumNArgs` to this where it was warranted

Along the way I noticed the error output formatting was inconsistent,
so I brought it inline with the `lint` command as that was implemented
first. I also added a path exists check to `lint`.