### PR TITLE
Update track id detection to use absolute path

### DIFF
--- a/track/track.go
+++ b/track/track.go
@@ -19,7 +19,12 @@ func New(path string) (Track, error) {
 	track := Track{
 		path: filepath.FromSlash(path),
 	}
-	track.ID = filepath.Base(path)
+
+	ap, err := filepath.Abs(track.path)
+	if err != nil {
+		return track, err
+	}
+	track.ID = filepath.Base(ap)
 
 	c, err := NewConfig(filepath.Join(path, "config.json"))
 	if err != nil {

--- a/track/track_test.go
+++ b/track/track_test.go
@@ -1,6 +1,7 @@
 package track
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,5 +31,32 @@ func TestNewTrack(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected to find exercise %s", slug)
 		}
+	}
+}
+
+func TestTrackID(t *testing.T) {
+
+	tests := []struct {
+		root     string
+		path     string
+		expected string
+	}{
+		{"../fixtures", "numbers", "numbers"},
+		{"../fixtures/numbers", ".", "numbers"},
+	}
+
+	cwd, _ := os.Getwd()
+	defer func() { os.Chdir(cwd) }()
+	for _, test := range tests {
+		err := os.Chdir(test.root)
+		assert.NoError(t, err)
+
+		track, err := New(test.path)
+		assert.NoError(t, err)
+
+		assert.Equal(t, test.expected, track.ID)
+
+		// reset working directory for each test
+		os.Chdir(cwd)
 	}
 }


### PR DESCRIPTION
In adding a track.ID property an issue was introduced where configlet does not properly set a track's ID when running `configlet lint .` within a track's root directory. 

This change ensures that filepath.Base is called on a absolute path, as opposed to a relative path. 