### PR TITLE
Update the list of supported Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 go:
   - 1.8
+  - 1.9
   - tip
 
 install: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Exercism would be impossible without people like you being willing to spend time
 
 ## Dependencies
 
-You'll need Go version 1.7 or higher. Follow the directions on http://golang.org/doc/install
+You'll need Go version 1.8 or higher. Follow the directions on http://golang.org/doc/install
 
 ## Development
 


### PR DESCRIPTION
I updated CONTRIBUTING.md so that we have parity with the travis build matrix and added Go 1.9 since it is the latest stable release. 