### PR TITLE
lint: WIP Add regex validation check to ensure patterns work in Go and Ruby

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 
 	"github.com/exercism/configlet/track"
 	"github.com/exercism/configlet/ui"
@@ -95,6 +96,10 @@ func lintTrack(path string) bool {
 		{
 			check: duplicateTrackUUID,
 			msg:   "The following UUID was found in multiple Exercism tracks. Each exercise UUID must be unique across tracks.\n%v",
+		},
+		{
+			check: invalidRegexPatterns,
+			msg:   "-> The following pattern %q failed to compile. Please check the Regex pattern.\n",
 		},
 	}
 
@@ -311,6 +316,19 @@ func duplicateTrackUUID(t track.Track) []string {
 	}
 
 	return []string{}
+}
+
+func invalidRegexPatterns(t track.Track) []string {
+	patterns := t.Config.Patterns()
+
+	failedPatterns := []string{}
+	for _, pattern := range patterns {
+		if _, err := regexp.Compile(pattern); err != nil {
+			failedPatterns = append(failedPatterns, regexp.QuoteMeta(pattern))
+		}
+	}
+
+	return failedPatterns
 }
 
 func init() {

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -220,7 +220,21 @@ func TestDuplicateTrackUUID(t *testing.T) {
 
 }
 
-func TestInvalidRubyRegexPatterns(t *testing.T) {
+func TestUnsupportedGoRegexPatterns(t *testing.T) {
+	track := track.Track{
+		Config: track.Config{
+			PatternGroup: track.PatternGroup{
+				SolutionPattern: "example(?!_test.go)",
+			},
+		},
+	}
+
+	// An unsupported regexp pattern should fail when being compile by Go.
+	patterns := unsupportedRegexPatterns(track)
+	assert.Equal(t, "solution_pattern", patterns[0])
+}
+
+func TestUnsupportedRubyRegexPatterns(t *testing.T) {
 	fakeEndpoint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		fmt.Fprintln(w, `{"patterns": ["ignore_pattern"]}`)
@@ -229,22 +243,21 @@ func TestInvalidRubyRegexPatterns(t *testing.T) {
 	ts := httptest.NewServer(fakeEndpoint)
 	defer ts.Close()
 
-	saved := UUIDValidationURL
-	UUIDValidationURL = ts.URL
-	defer func() { UUIDValidationURL = saved }()
+	saved := RegexValidationURL
+	RegexValidationURL = ts.URL
+	defer func() { RegexValidationURL = saved }()
 
 	expected := []string{"ignore_pattern"}
 	track := track.Track{
 		Config: track.Config{
 			PatternGroup: track.PatternGroup{
-				IgnorePattern:   "example(?!_test.go)",
-				SolutionPattern: "example",
+				IgnorePattern:   "example(?s:_test.go)",
+				SolutionPattern: "[Ee]xample",
 			},
 		},
 	}
 
-	uuids := invalidRubyRegexPatterns(track)
-	assert.Equal(t, len(expected), len(uuids))
-	assert.Equal(t, expected[0], uuids[0])
-
+	patterns := unsupportedRegexPatterns(track)
+	assert.Equal(t, len(expected), len(patterns))
+	assert.Equal(t, expected[0], patterns[0])
 }

--- a/track/config.go
+++ b/track/config.go
@@ -10,6 +10,7 @@ import (
 type PatternGroup struct {
 	SolutionPattern string `json:"solution_pattern"`
 	TestPattern     string `json:"test_pattern"`
+	IgnorePattern   string `json:"ignore_pattern"`
 }
 
 // Config is an Exercism track configuration.
@@ -29,6 +30,7 @@ type Config struct {
 func NewConfig(path string) (Config, error) {
 	c := Config{
 		PatternGroup: PatternGroup{
+			IgnorePattern:   "(?i)[Ee]xample",
 			SolutionPattern: "[Ee]xample",
 			TestPattern:     "(?i)test",
 		},
@@ -43,4 +45,12 @@ func NewConfig(path string) (Config, error) {
 		return c, fmt.Errorf("invalid config %s -- %s", path, err.Error())
 	}
 	return c, nil
+}
+
+func (c Config) Patterns() []string {
+	return []string{
+		c.IgnorePattern,
+		c.SolutionPattern,
+		c.TestPattern,
+	}
 }

--- a/track/config.go
+++ b/track/config.go
@@ -30,7 +30,7 @@ type Config struct {
 func NewConfig(path string) (Config, error) {
 	c := Config{
 		PatternGroup: PatternGroup{
-			IgnorePattern:   "(?i)[Ee]xample",
+			IgnorePattern:   "[Ee]xample",
 			SolutionPattern: "[Ee]xample",
 			TestPattern:     "(?i)test",
 		},
@@ -45,12 +45,4 @@ func NewConfig(path string) (Config, error) {
 		return c, fmt.Errorf("invalid config %s -- %s", path, err.Error())
 	}
 	return c, nil
-}
-
-func (c Config) Patterns() []string {
-	return []string{
-		c.IgnorePattern,
-		c.SolutionPattern,
-		c.TestPattern,
-	}
 }


### PR DESCRIPTION
This is a rough set of changes for handling regex validation for Go and Ruby - issue #50. 
This change contains a stubbed out version of the proposed Regex Validation Endpoint for the Exercism API.

The general thought process for the API is that it would take a map of patterns and return back a list of pattern names that failed to compile on Ruby. 

```
curl -v -XPOST  "http://exercism.io/api/v1/patterns" -H "Content-Type: application/json" --data '{                              
"solution_pattern": "[Ee]xample",
"test_pattern": "*test.go",
"ignore_pattern": "[Ee]xample"
}'
...
< HTTP/1.1 204 No Content
...
```

The service responds with HTTP status 204 if all is well, or 422 if one ore more patterns fail to validate. In the case of a validation issue the payload contains the name of the failed pattern.

```
 curl -v -XPOST  "http://exercism.io/api/v1/patterns" -H "Content-Type: application/json" --data '{                              
"solution_pattern": "[Ee]xample",
"test_pattern": "*test.go",
"ignore_pattern": "(?s:example)"
}'
...
< HTTP/1.1 422 Unprocessable Entity
...
{"patterns":["ignore_pattern"]}
```

#### Todo
- [ ] Finalize what the regex validation API looks like.
- [ ] Break out HTTP requests into a single client.
- [ ] Clean up regex validation functions. 