### PR TITLE
Add links to authors in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,12 @@ Exercism configlet follows [semantic versioning](http://semver.org/).
 * [#9](https://github.com/exercism/configlet/pull/9) Simplify gofmt style - [@ferhatelmas]
 * [#6](https://github.com/exercism/configlet/pull/6) Run tests on travis - [@kytrinyx]
 * [#5](https://github.com/exercism/configlet/pull/5) Ignore img directory - [@ryanplusplus]
+
+[@Insti]: https://github.com/Insti
+[@ferhatelmas]: https://github.com/ferhatelmas
+[@kytrinyx]: https://github.com/kytrinyx
+[@nywilken]: https://github.com/nywilken
+[@robphoenix]: https://github.com/robphoenix
+[@rpottsoh]: https://github.com/rpottsoh
+[@ryanplusplus]: https://github.com/ryanplusplus
+[@stkent]: https://github.com/stkent


### PR DESCRIPTION
The authors were almost linked up, but we were missing the target URLs for them.

**before**

<img width="616" alt="screen shot 2017-09-24 at 1 53 06 pm" src="https://user-images.githubusercontent.com/276834/30786219-e074e114-a12f-11e7-9b41-90435e797775.png">

**after**

<img width="581" alt="screen shot 2017-09-24 at 1 54 02 pm" src="https://user-images.githubusercontent.com/276834/30786222-e61b5454-a12f-11e7-9cac-eeaf09631c81.png">
