### PR TITLE
Remove coupling between description and metadata

### DIFF
--- a/fixtures/granular-metadata-overrides/exercises/description-example/.meta/description.md
+++ b/fixtures/granular-metadata-overrides/exercises/description-example/.meta/description.md
@@ -1,0 +1,1 @@
+This is a custom description.

--- a/fixtures/granular-metadata-overrides/exercises/metadata-example/.meta/metadata.yml
+++ b/fixtures/granular-metadata-overrides/exercises/metadata-example/.meta/metadata.yml
@@ -1,0 +1,2 @@
+---
+source: "The web."

--- a/fixtures/granular-metadata-overrides/problem-specifications/exercises/description-example/description.md
+++ b/fixtures/granular-metadata-overrides/problem-specifications/exercises/description-example/description.md
@@ -1,0 +1,1 @@
+This is a shared description.

--- a/fixtures/granular-metadata-overrides/problem-specifications/exercises/description-example/metadata.yml
+++ b/fixtures/granular-metadata-overrides/problem-specifications/exercises/description-example/metadata.yml
@@ -1,0 +1,3 @@
+---
+source: "The internet."
+source_url: "http://example.com"

--- a/fixtures/granular-metadata-overrides/problem-specifications/exercises/metadata-example/description.md
+++ b/fixtures/granular-metadata-overrides/problem-specifications/exercises/metadata-example/description.md
@@ -1,0 +1,1 @@
+This is a shared description.

--- a/fixtures/granular-metadata-overrides/problem-specifications/exercises/metadata-example/metadata.yml
+++ b/fixtures/granular-metadata-overrides/problem-specifications/exercises/metadata-example/metadata.yml
@@ -1,0 +1,3 @@
+---
+source: "The internet."
+source_url: "http://example.com"

--- a/track/exercise_readme_test.go
+++ b/track/exercise_readme_test.go
@@ -72,7 +72,9 @@ func TestExerciseReadmeTrackInsertDeprecation(t *testing.T) {
 		{"inserts-old", "deprecated insert\n"},
 	}
 
+	originalSpecPath := ProblemSpecificationsPath
 	ProblemSpecificationsPath = filepath.FromSlash("../fixtures/problem-specifications")
+	defer func() { ProblemSpecificationsPath = originalSpecPath }()
 	for _, test := range tests {
 		readme, err := NewExerciseReadme(root, test.trackID, "fake")
 		assert.NoError(t, err)
@@ -91,7 +93,9 @@ func TestExerciseReadmeHintsDeprecation(t *testing.T) {
 		{"hints-old", "deprecated hints\n"},
 	}
 
+	originalSpecPath := ProblemSpecificationsPath
 	ProblemSpecificationsPath = filepath.FromSlash("../fixtures/problem-specifications")
+	defer func() { ProblemSpecificationsPath = originalSpecPath }()
 	for _, test := range tests {
 		readme, err := NewExerciseReadme(root, test.trackID, "fake")
 		assert.NoError(t, err)

--- a/track/problem_specification_test.go
+++ b/track/problem_specification_test.go
@@ -9,14 +9,16 @@ import (
 
 func TestNewProblemSpecification(t *testing.T) {
 	tests := []struct {
-		desc     string
-		slug     string
-		specPath string
-		expected ProblemSpecification
+		desc      string
+		slug      string
+		trackPath string
+		specPath  string
+		expected  ProblemSpecification
 	}{
 		{
-			desc: "shared spec if custom is missing",
-			slug: "one",
+			desc:      "shared spec if custom is missing",
+			slug:      "one",
+			trackPath: filepath.FromSlash("../fixtures/numbers"),
 			expected: ProblemSpecification{
 				Description: "This is one.\n",
 				Source:      "The internet.",
@@ -24,8 +26,9 @@ func TestNewProblemSpecification(t *testing.T) {
 			},
 		},
 		{
-			desc: "custom spec overrides shared",
-			slug: "two",
+			desc:      "custom spec overrides shared",
+			slug:      "two",
+			trackPath: filepath.FromSlash("../fixtures/numbers"),
 			expected: ProblemSpecification{
 				Description: "This is two, customized.\n",
 				Source:      "The web.",
@@ -33,29 +36,51 @@ func TestNewProblemSpecification(t *testing.T) {
 			},
 		},
 		{
-			desc:     "shared spec from alternate problem-specifications location",
-			slug:     "one",
-			specPath: filepath.FromSlash("../fixtures/alternate/problem-specifications"),
+			desc:      "shared spec from alternate problem-specifications location",
+			slug:      "one",
+			trackPath: filepath.FromSlash("../fixtures/numbers"),
+			specPath:  filepath.FromSlash("../fixtures/alternate/problem-specifications"),
 			expected: ProblemSpecification{
 				Description: "This is the alternate one.\n",
 				Source:      "The internet.",
 				SourceURL:   "http://example.com",
 			},
 		},
+		{
+			desc:      "custom spec metadata with shared description",
+			slug:      "metadata-example",
+			trackPath: filepath.FromSlash("../fixtures/granular-metadata-overrides"),
+			specPath:  filepath.FromSlash("../fixtures/granular-metadata-overrides/problem-specifications"),
+			expected: ProblemSpecification{
+				Description: "This is a shared description.\n",
+				Source:      "The web.",
+				SourceURL:   "",
+			},
+		},
+		{
+			desc:      "shared spec metadata with custom description",
+			slug:      "description-example",
+			trackPath: filepath.FromSlash("../fixtures/granular-metadata-overrides"),
+			specPath:  filepath.FromSlash("../fixtures/granular-metadata-overrides/problem-specifications"),
+			expected: ProblemSpecification{
+				Description: "This is a custom description.\n",
+				Source:      "The internet.",
+				SourceURL:   "http://example.com",
+			},
+		},
 	}
-
 	originalSpecPath := ProblemSpecificationsPath
 	defer func() { ProblemSpecificationsPath = originalSpecPath }()
 
 	for _, test := range tests {
 		ProblemSpecificationsPath = test.specPath
-		root := filepath.FromSlash("../fixtures")
-		spec, err := NewProblemSpecification(root, "numbers", test.slug)
+		root, trackID := filepath.Dir(test.trackPath), filepath.Base(test.trackPath)
+		spec, err := NewProblemSpecification(root, trackID, test.slug)
 		assert.NoError(t, err)
 
-		assert.Equal(t, test.expected.Description, spec.Description)
 		assert.Equal(t, test.expected.Source, spec.Source)
 		assert.Equal(t, test.expected.SourceURL, spec.SourceURL)
+		assert.Equal(t, test.expected.Description, spec.Description)
 	}
 }
 


### PR DESCRIPTION
 Currently, the loading of a custom exercise readme description (i.e `$exercise_path/.meta/description.md`)  requires that a copy of the `metadata.yml` file exist within `$exercise_path/.meta` . This change removes that coupling so that maintainers can override descriptions without the need of a duplicated `.metadata.yml` file. 

closes #65 