### PR TITLE
Add a snake case version of the slug

### DIFF
--- a/track/problem_specification.go
+++ b/track/problem_specification.go
@@ -64,6 +64,11 @@ func (spec *ProblemSpecification) MixedCaseName() string {
 	return strings.Replace(spec.Name(), " ", "", -1)
 }
 
+// SnakeCaseName converts the slug to snake case.
+func (spec *ProblemSpecification) SnakeCaseName() string {
+	return strings.Replace(spec.Slug, "-", "_", -1)
+}
+
 // Credits are a markdown-formatted version of the source of the exercise.
 func (spec *ProblemSpecification) Credits() string {
 	if spec.SourceURL == "" {

--- a/track/problem_specification_test.go
+++ b/track/problem_specification_test.go
@@ -67,21 +67,25 @@ func TestProblemSpecificationName(t *testing.T) {
 		slug  string
 		name  string
 		mixed string
+		snake string
 	}{
 		{
 			slug:  "apple",
 			name:  "Apple",
 			mixed: "Apple",
+			snake: "apple",
 		},
 		{
 			slug:  "apple-pie",
 			name:  "Apple Pie",
 			mixed: "ApplePie",
+			snake: "apple_pie",
 		},
 		{
 			slug:  "1-apple-per-day",
 			name:  "1 Apple Per Day",
 			mixed: "1ApplePerDay",
+			snake: "1_apple_per_day",
 		},
 	}
 
@@ -89,6 +93,7 @@ func TestProblemSpecificationName(t *testing.T) {
 		spec := ProblemSpecification{Slug: test.slug}
 		assert.Equal(t, test.name, spec.Name())
 		assert.Equal(t, test.mixed, spec.MixedCaseName())
+		assert.Equal(t, test.snake, spec.SnakeCaseName())
 	}
 }
 


### PR DESCRIPTION
Tracks should be able to generate the expected filename for an exercise,
in order to provide the exact command that people need to use to run
the tests for an exercise.

The typical naming conventions are:

- `kebab-case` (e.g. JavaScript)
- `snake_case` (e.g. Ruby)
- `MixedCase` (e.g. Groovy)

We already have support for `kebab-case` (the slug itself)
and `MixedCase`. This adds the missing `snake_case`.

Needed in order to proceed with https://github.com/exercism/meta/issues/92