### PR TITLE
tree: fix bad indenting in fixture

### DIFF
--- a/fixtures/tree/config.json
+++ b/fixtures/tree/config.json
@@ -53,8 +53,8 @@
       "difficulty": 3,
       "slug": "seven",
       "topics": [
-	"spycraft",
-	"martinis"
+        "spycraft",
+        "martinis"
       ],
       "unlocked_by": null,
       "uuid": "007"


### PR DESCRIPTION
Fix a tabs/spaces mixup in the tree commands config.json test fixture.