### PR TITLE
Git ignore .editorconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/*tgz
 
 # dep
 vendor/
+
+# editorconfig
+# see: http://editorconfig.org/
+.editorconfig


### PR DESCRIPTION
Related to #104, using an .editorconfig lets us maintain consistent
styling for the non-Go parts of the repo. This change will not force
anyone to use one, but will ignore it should it be present.