### PR TITLE
[DNM] UUID doctor command

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/exercism/configlet/track"
+	"github.com/exercism/configlet/ui"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+var repairUUID bool
+
+// doctorCmd represents the doctor command
+var doctorCmd = &cobra.Command{
+	Use:   "doctor " + pathExample,
+	Short: "Check track configuration for malformed UUIDs",
+	Long: `The uuid doctor command validates UUIDs within a track's configuration file.
+Any malformed UUID, along with its Slug, will be captured in the diagnostic report.
+To automatically fix malformed UUIDs specify the --repair flag at runtime.`,
+
+	Run:  runDiagnostic,
+	Args: cobra.ExactArgs(1),
+}
+
+func runDiagnostic(cmd *cobra.Command, args []string) {
+	path := filepath.FromSlash(args[0])
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		ui.PrintError("path not found:", path)
+		os.Exit(1)
+	}
+
+	t, err := track.New(path)
+	if err != nil {
+		ui.PrintError(err)
+		os.Exit(1)
+	}
+
+	var badUUIDs []string
+	for _, exercise := range t.Config.Exercises {
+		if _, err := uuid.Parse(exercise.UUID); err == nil {
+			continue
+		}
+
+		badUUIDs = append(badUUIDs, exercise.UUID)
+		fmt.Fprintf(os.Stderr, "[X] %s (%s:%s)\n", exercise.UUID, t.ID, exercise.Slug)
+	}
+
+	if repairUUID {
+		configPath := filepath.Join(path, "config.json")
+		b, err := ioutil.ReadFile(configPath)
+		if err != nil {
+			ui.PrintError(err)
+			os.Exit(1)
+		}
+
+		for _, u := range badUUIDs {
+			newUUID := uuid.New().String()
+			b = bytes.Replace(b, []byte(u), []byte(newUUID), 1)
+		}
+
+		err = ioutil.WriteFile(configPath, b, os.FileMode(0644))
+		if err != nil {
+			ui.PrintError(err)
+			os.Exit(1)
+		}
+	}
+}
+
+func init() {
+	uuidCmd.AddCommand(doctorCmd)
+	doctorCmd.Flags().BoolVarP(&repairUUID, "repair", "r", false, "repair malformed UUIDs")
+}


### PR DESCRIPTION
An initial attempt to adding a diagnostic command for validating and repairing exercise UUIDs within a track. See sample output below.

This is something I put together, as a quick one off, to fix tracks with invalid UUIDs. I'm wondering if the doctor command is something worth having. The command as it stands is a bit rough, in that it reads the raw JSON file, replaces some bits, and spits it back out. Basically, side stepping the whole JSON ordering, munging for now to fix UUIDs. 

I would love your thoughts, feedback, and I always welcome the review 🙇 


```bash
dev [0] go-1.9.2 in ~/Development/oss/exercism/tracks/ 
> ls -1 | xargs -n1 -I{} configlet uuid doctor {} 2>&1

[X] 03808072-0228-6580-7a9b-cc709a8a5b8c0e600b9 (bash:atbash-cipher)
[X] d42g42d7-21b1-4daf-8ddc-a2ab9ee07c98 (clojure:spiral-matrix)
[X] 6efa02be-0f9e-1d80-7efb-536d383535c98b1d883 (common-lisp:acronym)
[X] ba4e0186-0389-af80-d3e4-695dfc4e63bff1fa503 (cpp:atbash-cipher)
[X] ce9fd8ac-0beb-1a80-4ff6-be19ce1540d905c31b7 (cpp:bracket-push)
[X] ea8d6224-0440-6d80-1569-a04127908a200d2ecf0 (cpp:pangram)
[X] d6657d4a-0257-0c80-6667-fddd127a571f0ad1fd4 (dart:raindrops)
[X] 765b5bcf-00e0-d180-ea7f-92dae26e6da0b30151c (delphi:hello-world)
[X] b38f504c-098e-fe80-896f-60e6c45751033d26161 (delphi:two-fer)
[X] cd80ef91-0451-c380-3d58-01a2ddff3029f430eea (delphi:bob)
[X] 9234d900-050c-5980-561b-e1f772ae2b9c7b3fd08 (delphi:leap)
[X] e8849e37-0b3e-ec80-c41c-c53f2a871f6ee59e2d6 (delphi:rna-transcription)
[X] 3b1391da-04c2-e580-30a5-6063e888da196dfba6a (delphi:raindrops)
[X] 68c5b50b-03c0-4880-af0f-9cfacb1ba507e837d12 (delphi:hamming)
[X] bb32f666-0f50-e480-9738-e4e3e8f7ece13c9b460 (delphi:bank-account)
[X] d5cae090-0626-c880-3b62-58ed5d301931de3171d (delphi:nucleotide-count)
[X] 4e538a24-0e30-2b80-2b3f-82ca73b593a81a8cc8d (delphi:etl)
[X] acf5b5ab-03d7-0e80-f419-255df25d35a2466a421 (delphi:grains)
[X] d8093412-0665-0280-b4ae-edd0a7b483a316f236b (delphi:collatz-conjecture)
[X] 311b59d8-01ed-0780-14a9-fa94a2937508a4fbf40 (delphi:beer-song)
[...]

```
