### PR TITLE
lint: refactoring for higher abstractions

### DIFF
--- a/track/config.go
+++ b/track/config.go
@@ -22,6 +22,26 @@ type Config struct {
 	PatternGroup
 }
 
+// ExerciseSlugs returns all defined slugs of config
+func (c Config) ExerciseSlugs() []string {
+	var slugs []string
+	for _, e := range c.Exercises {
+		slugs = append(slugs, e.Slug)
+	}
+	return slugs
+}
+
+// ExerciseUUIDs returns all defined UUIDs of exercises
+func (c Config) ExerciseUUIDs(withEmpty bool) []string {
+	var ids []string
+	for _, e := range c.Exercises {
+		if withEmpty || e.HasUUID() {
+			ids = append(ids, e.UUID)
+		}
+	}
+	return ids
+}
+
 // NewConfig loads a track configuration file.
 // The config has a default solution and test pattern if not provided in the file.
 // The solution pattern is used to determine if an exercise has a sample solution.

--- a/track/exercise.go
+++ b/track/exercise.go
@@ -15,6 +15,21 @@ type Exercise struct {
 	TestSuitePath string
 }
 
+// Exercises is a slice of Exercise to define functions
+type Exercises []Exercise
+
+// Fold iterates over slice, runs given function and collects slugs
+func (es Exercises) Fold(isValid func(Exercise) bool) (valid []string, invalid []string) {
+	for _, e := range es {
+		if isValid(e) {
+			valid = append(valid, e.Slug)
+		} else {
+			invalid = append(invalid, e.Slug)
+		}
+	}
+	return
+}
+
 // NewExercise loads an exercise.
 func NewExercise(root string, pg PatternGroup) (Exercise, error) {
 	ex := Exercise{

--- a/track/exercise_metadata.go
+++ b/track/exercise_metadata.go
@@ -12,3 +12,21 @@ type ExerciseMetadata struct {
 	IsCore       bool   `json:"core"`
 	IsDeprecated bool   `json:"deprecated"`
 }
+
+// HasUUID checks if UUID is defined
+func (e ExerciseMetadata) HasUUID() bool { return e.UUID != "" }
+
+// ExerciseMetadataList is a slice of ExerciseMetadata to define functions
+type ExerciseMetadataList []ExerciseMetadata
+
+// Fold iterates over slice, runs given function and collects slugs
+func (els ExerciseMetadataList) Fold(isValid func(ExerciseMetadata) bool) (valid []string, invalid []string) {
+	for _, e := range els {
+		if isValid(e) {
+			valid = append(valid, e.Slug)
+		} else {
+			invalid = append(invalid, e.Slug)
+		}
+	}
+	return
+}

--- a/track/track.go
+++ b/track/track.go
@@ -14,6 +14,15 @@ type Track struct {
 	path             string
 }
 
+// ExerciseSlugs returns all implemented exercise slugs of track
+func (t Track) ExerciseSlugs() []string {
+	var slugs []string
+	for _, e := range t.Exercises {
+		slugs = append(slugs, e.Slug)
+	}
+	return slugs
+}
+
 // New loads a track.
 func New(path string) (Track, error) {
 	track := Track{


### PR DESCRIPTION
Implementation of checkers in lint command started to be [repetitive](https://github.com/exercism/configlet/pull/98/files#r145857260). This tries to create an abstraction to make adding a new checker easier.