### PR TITLE
Add filter for unsupported exercise directories

### DIFF
--- a/fixtures/unsupported-exercise-names/config.json
+++ b/fixtures/unsupported-exercise-names/config.json
@@ -1,0 +1,13 @@
+{
+  "slug": "unsupported-exercise-names",
+  "repository": "https://github.com/exercism/unsupported-exercise-names",
+  "active": true,
+  "solution_pattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.ext",
+  "exercises": [
+    {
+      "slug": "some-valid-exercise",
+      "topics": [],
+      "difficulty": 1
+    }
+  ]
+}

--- a/fixtures/unsupported-exercise-names/exercises/.another-ignored-exercise/example.ext
+++ b/fixtures/unsupported-exercise-names/exercises/.another-ignored-exercise/example.ext
@@ -1,0 +1,1 @@
+This file was intentionally created to test the handling of exercise directory names begging with a `.` or `_`. Configlet should ignored them.

--- a/fixtures/unsupported-exercise-names/exercises/_ignored-exercise/example.ext
+++ b/fixtures/unsupported-exercise-names/exercises/_ignored-exercise/example.ext
@@ -1,0 +1,1 @@
+This file was intentionally created to test the handling of exercise directory names begging with a `.` or `_`. Configlet should ignored them.

--- a/track/track.go
+++ b/track/track.go
@@ -3,6 +3,7 @@ package track
 import (
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
 )
 
 // Track is a collection of Exercism exercises for a programming language.
@@ -44,9 +45,15 @@ func New(path string) (Track, error) {
 		return track, err
 	}
 
+	// Valid exercise directory names do not begin with `.` or `_`.
+	re := regexp.MustCompile("^[._]")
 	for _, file := range files {
 		if file.IsDir() {
-			fp := filepath.Join(dir, file.Name())
+			fn := file.Name()
+			if re.MatchString(fn) {
+				continue
+			}
+			fp := filepath.Join(dir, fn)
 
 			ex, err := NewExercise(fp, track.Config.PatternGroup)
 			if err != nil {

--- a/track/track_test.go
+++ b/track/track_test.go
@@ -60,3 +60,12 @@ func TestTrackID(t *testing.T) {
 		os.Chdir(cwd)
 	}
 }
+
+func TestInvalidExerciseName(t *testing.T) {
+	track, err := New("../fixtures/unsupported-exercise-names")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "unsupported-exercise-names", track.ID)
+
+	assert.Equal(t, 0, len(track.Exercises), "Expected to find no exercises.")
+}


### PR DESCRIPTION
There is currently an issue where hidden directories (those beginning with a `.` or `_`) are being treated as exercise slugs if they reside under `track-root/exercises/...`. This change introduces a regular expression that skips any directory under `track-root/exercises` that begins with either a `.` or `_`. 

closes #108