### PR TITLE
Add Upgrade command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,14 +16,14 @@
 [[projects]]
   branch = "nextercism"
   name = "github.com/exercism/cli"
-  packages = ["config","debug"]
-  revision = "9c2c5857da4af84af2973a04f68402116e1b5f43"
+  packages = ["cli","config","debug"]
+  revision = "63dae2f74c28b9bcfaf1920dd57603c3b8971b4b"
 
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  revision = "629574ca2a5df945712d3079857300b5e4da0236"
-  version = "v1.4.2"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
-  revision = "83588e72410abfbe4df460eeb6f30841ae47d4c4"
+  revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
   branch = "master"
@@ -64,26 +64,20 @@
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
-  version = "v1.7.3"
+  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
+  version = "v1.7.6"
 
 [[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
-
-[[projects]]
-  branch = "generalize-cli-updater"
-  name = "github.com/nywilken/cli"
-  packages = ["cli","debug"]
-  revision = "60a3b6dff2d61e4fb26b56d46a32cbe405fe77ea"
+  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
-  version = "v1.0.1"
+  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -94,26 +88,26 @@
 [[projects]]
   name = "github.com/spf13/afero"
   packages = [".","mem"]
-  revision = "8d919cbe7e2627e417f3e45c3c0e489a5b7e2536"
-  version = "v1.0.0"
+  revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/spf13/cast"
   packages = ["."]
-  revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
-  version = "v1.1.0"
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "b26b538f693051ac6518e65672de3144ce3fbedc"
+  revision = "a1e4933ab784095895e33dbe9f001ba10cfe2060"
 
 [[projects]]
   branch = "master"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
+  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -125,35 +119,35 @@
   branch = "master"
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "1a0c4a370c3e8286b835467d2dfcdaf636c3538b"
+  revision = "aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5"
 
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "a0f4589a76f1f83070cb9e5613809e1d07b97c13"
+  revision = "f6cff0780e542efa0c8e864dc8fa522808f6a598"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
   packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
-  revision = "be25de41fadfae372d6470bda81ca6beb55ef551"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
-  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "25c4ec802a7d637f88d584ab26798e94ad14c13b"
+  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
+  version = "v2.1.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c653694e778fb52b3e67de6b269f1ba277e05ef3700b62e32a3fd58fafdb900f"
+  inputs-digest = "b52c51de3502402b0d4ab63626eb8b999063971d4d24ca3567707bb57fbf46f4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,14 +16,8 @@
 [[projects]]
   branch = "nextercism"
   name = "github.com/exercism/cli"
-  packages = ["cli","config","debug"]
+  packages = ["cli"]
   revision = "63dae2f74c28b9bcfaf1920dd57603c3b8971b4b"
-
-[[projects]]
-  name = "github.com/fsnotify/fsnotify"
-  packages = ["."]
-  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
-  version = "v1.4.7"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -45,12 +39,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
-  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
-
-[[projects]]
-  branch = "master"
   name = "github.com/inconshreveable/go-update"
   packages = [".","internal/binarydist","internal/osext"]
   revision = "8152e7eb6ccf8679a64582a66b78519688d156ad"
@@ -62,40 +50,10 @@
   version = "v1.0"
 
 [[projects]]
-  name = "github.com/magiconair/properties"
-  packages = ["."]
-  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
-  version = "v1.7.6"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/mapstructure"
-  packages = ["."]
-  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
-
-[[projects]]
-  name = "github.com/pelletier/go-toml"
-  packages = ["."]
-  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
-  version = "v1.1.0"
-
-[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
-
-[[projects]]
-  name = "github.com/spf13/afero"
-  packages = [".","mem"]
-  revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
-  version = "v1.0.2"
-
-[[projects]]
-  name = "github.com/spf13/cast"
-  packages = ["."]
-  revision = "8965335b8c7107321228e3e3702cab9832751bac"
-  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -104,40 +62,16 @@
   revision = "a1e4933ab784095895e33dbe9f001ba10cfe2060"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/spf13/jwalterweatherman"
-  packages = ["."]
-  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
-
-[[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/spf13/viper"
-  packages = ["."]
-  revision = "aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5"
-
-[[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
-
-[[projects]]
-  branch = "master"
-  name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "f6cff0780e542efa0c8e864dc8fa522808f6a598"
-
-[[projects]]
-  name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -148,6 +82,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b52c51de3502402b0d4ab63626eb8b999063971d4d24ca3567707bb57fbf46f4"
+  inputs-digest = "eb0a5a01a48a08b009af2e7be43ff340ecc87a2034fa5ceadadaca26574e04be"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,10 +2,28 @@
 
 
 [[projects]]
+  name = "github.com/blang/semver"
+  packages = ["."]
+  revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
+  version = "v3.5.1"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
+
+[[projects]]
+  branch = "nextercism"
+  name = "github.com/exercism/cli"
+  packages = ["cli","config","debug"]
+  revision = "9c2c5857da4af84af2973a04f68402116e1b5f43"
+
+[[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "629574ca2a5df945712d3079857300b5e4da0236"
+  version = "v1.4.2"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -26,10 +44,40 @@
   revision = "83588e72410abfbe4df460eeb6f30841ae47d4c4"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/hcl"
+  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/inconshreveable/go-update"
+  packages = [".","internal/binarydist","internal/osext"]
+  revision = "8152e7eb6ccf8679a64582a66b78519688d156ad"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
+  version = "v1.7.3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -38,10 +86,28 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/spf13/afero"
+  packages = [".","mem"]
+  revision = "8d919cbe7e2627e417f3e45c3c0e489a5b7e2536"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "b26b538f693051ac6518e65672de3144ce3fbedc"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -50,10 +116,28 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "1a0c4a370c3e8286b835467d2dfcdaf636c3538b"
+
+[[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "a0f4589a76f1f83070cb9e5613809e1d07b97c13"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/text"
+  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  revision = "be25de41fadfae372d6470bda81ca6beb55ef551"
 
 [[projects]]
   branch = "v2"
@@ -64,6 +148,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b797f3e2021c775cd9152989c02b8073ce2d23deadc158e9b4985adbcc4369d9"
+  inputs-digest = "001464ccf618d202feabff112b3ee3551e23f1d507eb0de116e88f04df8801a6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,7 +16,7 @@
 [[projects]]
   branch = "nextercism"
   name = "github.com/exercism/cli"
-  packages = ["cli","config","debug"]
+  packages = ["config","debug"]
   revision = "9c2c5857da4af84af2973a04f68402116e1b5f43"
 
 [[projects]]
@@ -72,6 +72,12 @@
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
+
+[[projects]]
+  branch = "generalize-cli-updater"
+  name = "github.com/nywilken/cli"
+  packages = ["cli","debug"]
+  revision = "60a3b6dff2d61e4fb26b56d46a32cbe405fe77ea"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
@@ -148,6 +154,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "001464ccf618d202feabff112b3ee3551e23f1d507eb0de116e88f04df8801a6"
+  inputs-digest = "c653694e778fb52b3e67de6b269f1ba277e05ef3700b62e32a3fd58fafdb900f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,3 +32,7 @@
 [[constraint]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
+
+[[constraint]]
+  branch = "nextercism"
+  name = "github.com/exercism/cli"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,6 +21,8 @@
 #  version = "2.4.0"
 
 
+ignored = ["github.com/exercism/cli/config","github.com/exercism/cli/debug" ]
+
 [[constraint]]
   branch = "master"
   name = "github.com/mattetti/uuid"
@@ -36,3 +38,4 @@
 [[constraint]]
   branch = "nextercism"
   name = "github.com/exercism/cli"
+

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,5 +34,5 @@
   name = "gopkg.in/yaml.v2"
 
 [[constraint]]
-  branch = "nextercism"
-  name = "github.com/exercism/cli"
+  branch = "generalize-cli-updater"
+  name = "github.com/nywilken/cli"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,5 +34,5 @@
   name = "gopkg.in/yaml.v2"
 
 [[constraint]]
-  branch = "generalize-cli-updater"
-  name = "github.com/nywilken/cli"
+  branch = "nextercism"
+  name = "github.com/exercism/cli"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,15 +5,21 @@ import (
 	"os"
 	"strings"
 
+	"github.com/exercism/cli/cli"
 	"github.com/exercism/configlet/ui"
 	"github.com/spf13/cobra"
 )
+
+// Version is the current version of the tool.
+const Version = "3.7.0"
 
 var (
 	// binaryName is this tool's given name. While we have named it configlet, others
 	// may choose to rename it. This var enables the use of it's name, whatever it is,
 	// in any help/usage text.
 	binaryName = os.Args[0]
+	//configletCLI is an updatable CLI binary.
+	configletCLI *cli.CLI
 	// pathExample is an illustration of the path argument necessary for some commands.
 	pathExample = "<path/to/track>"
 )
@@ -43,4 +49,9 @@ func Execute() {
 		ui.PrintError(err.Error())
 		os.Exit(-1)
 	}
+}
+
+func init() {
+	cli.ReleaseURL = "https://api.github.com/repos/exercism/configlet/releases"
+	configletCLI = cli.New(Version)
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,9 +1,8 @@
 package cmd
 
 import (
-	"github.com/exercism/cli/cli"
-	"github.com/exercism/cli/debug"
 	"github.com/exercism/configlet/ui"
+	"github.com/nywilken/cli/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -23,11 +22,7 @@ You can always delete this file.
 	`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
-			debug.Verbose = verbose
-		}
-
-		cli.LatestReleaseURL = "https://api.github.com/repos/exercism/configlet/releases/latest"
+		cli.ReleaseURL = "https://api.github.com/repos/exercism/configlet/releases"
 		c := cli.New(Version)
 		return runUpdate(c)
 	},
@@ -49,5 +44,4 @@ func runUpdate(c cli.Updater) error {
 
 func init() {
 	RootCmd.AddCommand(upgradeCmd)
-	upgradeCmd.Flags().BoolP("verbose", "v", false, "verbose output")
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"github.com/exercism/cli/cli"
+	"github.com/exercism/cli/debug"
+	"github.com/exercism/configlet/ui"
+	"github.com/spf13/cobra"
+)
+
+// upgradeCmd downloads and installs the most recent version of Configlet.
+var upgradeCmd = &cobra.Command{
+	Use:     "upgrade",
+	Aliases: []string{"u"},
+	Short:   "Upgrade to the latest version of Configlet.",
+	Long: `Upgrade to the latest version of Configlet.
+
+This finds and downloads the latest release, if you don't
+already have it.
+
+On Windows the old Configlet will be left on disk, marked as hidden.
+The next time you upgrade, the hidden file will be overwritten.
+You can always delete this file.
+	`,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
+			debug.Verbose = verbose
+		}
+
+		cli.LatestReleaseURL = "https://api.github.com/repos/exercism/configlet/releases/latest"
+		c := cli.New(Version)
+		return runUpdate(c)
+	},
+}
+
+// runUpdate updates Configlet to the latest available version, if it is out of date.
+func runUpdate(c cli.Updater) error {
+	ok, err := c.IsUpToDate()
+	if err != nil {
+		return err
+	}
+
+	if ok {
+		ui.Print("Your Configlet version is up to date.")
+		return nil
+	}
+	return c.Upgrade()
+}
+
+func init() {
+	RootCmd.AddCommand(upgradeCmd)
+	upgradeCmd.Flags().BoolP("verbose", "v", false, "verbose output")
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/exercism/cli/cli"
 	"github.com/exercism/configlet/ui"
 	"github.com/spf13/cobra"
@@ -20,25 +22,26 @@ The next time you upgrade, the hidden file will be overwritten.
 You can always delete this file.
 	`,
 
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cli.ReleaseURL = "https://api.github.com/repos/exercism/configlet/releases"
-		c := cli.New(Version)
-		return runUpdate(c)
+	Run: func(cmd *cobra.Command, args []string) {
+		runUpdate(configletCLI)
 	},
 }
 
 // runUpdate updates Configlet to the latest available version, if it is out of date.
-func runUpdate(c cli.Updater) error {
+func runUpdate(c cli.Updater) {
 	ok, err := c.IsUpToDate()
 	if err != nil {
-		return err
+		ui.PrintError(err)
 	}
 
 	if ok {
-		ui.Print("Your Configlet version is up to date.")
-		return nil
+		fmt.Println("Your CLI version is up to date.")
+		return
 	}
-	return c.Upgrade()
+
+	if err := c.Upgrade(); err != nil {
+		ui.PrintError(err)
+	}
 }
 
 func init() {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,16 +1,15 @@
 package cmd
 
 import (
+	"github.com/exercism/cli/cli"
 	"github.com/exercism/configlet/ui"
-	"github.com/nywilken/cli/cli"
 	"github.com/spf13/cobra"
 )
 
 // upgradeCmd downloads and installs the most recent version of Configlet.
 var upgradeCmd = &cobra.Command{
-	Use:     "upgrade",
-	Aliases: []string{"u"},
-	Short:   "Upgrade to the latest version of Configlet.",
+	Use:   "upgrade",
+	Short: "Upgrade to the latest version of Configlet.",
 	Long: `Upgrade to the latest version of Configlet.
 
 This finds and downloads the latest release, if you don't

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/exercism/configlet/ui"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeCLI struct {
+	UpToDate      bool
+	UpgradeCalled bool
+}
+
+func (fc *fakeCLI) IsUpToDate() (bool, error) {
+	return fc.UpToDate, nil
+}
+
+func (fc *fakeCLI) Upgrade() error {
+	fc.UpgradeCalled = true
+	return nil
+}
+
+func TestUpgrade(t *testing.T) {
+	oldOut := ui.Out
+	ui.Out = ioutil.Discard
+	defer func() { ui.Out = oldOut }()
+
+	tests := []struct {
+		desc     string
+		upToDate bool
+		expected bool
+	}{
+		{
+			desc:     "upgrade should be called for an outdated CLI",
+			upToDate: false,
+			expected: true,
+		},
+		{
+			desc:     "upgrade should not be called for an already updated CLI",
+			upToDate: true,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		fc := &fakeCLI{UpToDate: test.upToDate}
+
+		err := runUpdate(fc)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, fc.UpgradeCalled, test.desc)
+	}
+}

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -47,8 +47,7 @@ func TestUpgrade(t *testing.T) {
 	for _, test := range tests {
 		fc := &fakeCLI{UpToDate: test.upToDate}
 
-		err := runUpdate(fc)
-		assert.NoError(t, err)
+		runUpdate(fc)
 		assert.Equal(t, test.expected, fc.UpgradeCalled, test.desc)
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,13 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/exercism/cli/cli"
 	"github.com/exercism/configlet/ui"
 	"github.com/spf13/cobra"
 )
-
-// Version is the current version of the tool.
-const Version = "3.7.0"
 
 var checkLatestVersion bool
 
@@ -24,24 +20,22 @@ var versionCmd = &cobra.Command{
 }
 
 func runVersion(cmd *cobra.Command, args []string) {
-	cli.ReleaseURL = "https://api.github.com/repos/exercism/configlet/releases"
 	// we don't want any UI formatting prepended to this
-	fmt.Printf("configlet version %s\n", Version)
+	fmt.Printf("configlet version %s\n", configletCLI.Version)
 
 	if !checkLatestVersion {
 		return
 	}
 
-	c := cli.New(Version)
-	ok, err := c.IsUpToDate()
+	ok, err := configletCLI.IsUpToDate()
 	if err != nil {
 		ui.PrintError(err)
 		return
 	}
-	msg := "Your version is up to date."
+	msg := "Your CLI version is up to date."
 
 	if !ok {
-		msg = fmt.Sprintf("A new version is available. Run `%s upgrade` to update to %s", binaryName, c.LatestRelease.Version())
+		msg = fmt.Sprintf("A new CLI version is available. Run `%s upgrade` to update to %s", binaryName, configletCLI.LatestRelease.Version())
 	}
 	fmt.Println(msg)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Version is the current version of the tool.
-const Version = "3.7.0"
+const Version = "3.6.0"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/exercism/configlet/ui"
+	"github.com/nywilken/cli/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -20,8 +22,20 @@ var versionCmd = &cobra.Command{
 }
 
 func runVersion(cmd *cobra.Command, args []string) {
+	cli.ReleaseURL = "https://api.github.com/repos/exercism/configlet/releases"
 	// we don't want any UI formatting prepended to this
 	fmt.Printf("%s version %s\n", binaryName, Version)
+
+	c := cli.New(Version)
+	ok, err := c.IsUpToDate()
+	if err != nil {
+		ui.PrintError(err)
+	}
+
+	if !ok {
+		msg := fmt.Sprintf("There is a newer version of Configlet available (%s)", c.LatestRelease.Version())
+		ui.Print(msg)
+	}
 }
 
 func init() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,13 +3,15 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/exercism/cli/cli"
 	"github.com/exercism/configlet/ui"
-	"github.com/nywilken/cli/cli"
 	"github.com/spf13/cobra"
 )
 
 // Version is the current version of the tool.
-const Version = "3.6.0"
+const Version = "3.7.0"
+
+var checkLatestVersion bool
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
@@ -24,20 +26,27 @@ var versionCmd = &cobra.Command{
 func runVersion(cmd *cobra.Command, args []string) {
 	cli.ReleaseURL = "https://api.github.com/repos/exercism/configlet/releases"
 	// we don't want any UI formatting prepended to this
-	fmt.Printf("%s version %s\n", binaryName, Version)
+	fmt.Printf("configlet version %s\n", Version)
+
+	if !checkLatestVersion {
+		return
+	}
 
 	c := cli.New(Version)
 	ok, err := c.IsUpToDate()
 	if err != nil {
 		ui.PrintError(err)
+		return
 	}
+	msg := "Your version is up to date."
 
 	if !ok {
-		msg := fmt.Sprintf("There is a newer version of Configlet available (%s)", c.LatestRelease.Version())
-		ui.Print(msg)
+		msg = fmt.Sprintf("A new version is available. Run `%s upgrade` to update to %s", binaryName, c.LatestRelease.Version())
 	}
+	fmt.Println(msg)
 }
 
 func init() {
 	RootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().BoolVarP(&checkLatestVersion, "latest", "l", false, "check latest available version.")
 }


### PR DESCRIPTION
This change introduces a command for upgrading to the latest available version of Configlet. The upgrade command, is identical to the upgrade command used in the Exercism CLI. In fact, the underlying pkg `github.com/exercism/cli/cli` is being pulled into Configlet to download and upgrade the Configlet binary in-place. This change resolves #112 

**Note**: The pkg version of `github.com/exercism/cli/cli` is currently pinned to the Nextercism branch.

**Follow-Up**: The existing pkg structure of `github.com/exercism/cli/cli` seems a bit strange so I think a follow up, in the near future, might be to restructure the pkg or even break it out of `exercism/cli` into its own pkg for upgrading GitHub released binaries. 