### PR TITLE
Update configlet fmt to apply a definite ordering

### DIFF
--- a/cmd/fmt_example_test.go
+++ b/cmd/fmt_example_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ExampleFormat() {
-	diff, formatted, err := formatFile(filepath.FromSlash("../fixtures/format/unformatted/config.json"), formatTopics)
+	diff, formatted, err := formatFile(filepath.FromSlash("../fixtures/format/unformatted/config.json"), formatTopics, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -40,7 +40,7 @@ var configFiles = []string{
 
 func TestFormat(t *testing.T) {
 	for _, f := range configFiles {
-		_, actualConfig, err := formatFile(filepath.FromSlash(f), formatTopics)
+		_, actualConfig, err := formatFile(filepath.FromSlash(f), formatTopics, orderConfig)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -56,7 +56,7 @@ var maintainersFiles = []string{
 
 func TestMaintainers(t *testing.T) {
 	for _, f := range maintainersFiles {
-		_, actualMaintainers, err := formatFile(filepath.FromSlash(f), nil)
+		_, actualMaintainers, err := formatFile(filepath.FromSlash(f), nil, nil)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ordered_map.go
+++ b/cmd/ordered_map.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+)
+
+// generate json from a map given a particular ordering
+// https://stackoverflow.com/a/30673838/504550
+
+// KeyVal is the key-value component of an OrderedMap
+type KeyVal struct {
+	Key string
+	Val interface{}
+}
+
+// OrderedMap is a newtype which JSON-encodes an ordered map
+type OrderedMap []KeyVal
+
+// MarshalJSON implements the json.Marshaler interface
+func (omap OrderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+
+	buf.WriteString("{")
+	for i, kv := range omap {
+		if i != 0 {
+			buf.WriteString(",")
+		}
+		// marshal key
+		key, err := json.Marshal(kv.Key)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(key)
+		buf.WriteString(":")
+		// marshal value
+		val, err := json.Marshal(kv.Val)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(val)
+	}
+
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}
+
+// WithOrdering transforms an arbitrary string-keyed map into an OrderedMap.
+//
+// All keys contained in `order` are emitted in that order. If a given key is
+// not present in `dict`, it is omitted without error.
+//
+// After all ordered keys are emitted, all remaining keys are
+// emitted alphabetically.
+func WithOrdering(dict map[string]interface{}, order ...string) OrderedMap {
+	var om OrderedMap
+	for _, key := range order {
+		val, isPresent := dict[key]
+		if isPresent {
+			om = append(om, KeyVal{Key: key, Val: val})
+		}
+		delete(dict, key)
+	}
+
+	var unorderedKeys []string
+	for key := range dict {
+		unorderedKeys = append(unorderedKeys, key)
+	}
+	sort.Strings(unorderedKeys)
+	for _, key := range unorderedKeys {
+		val := dict[key]
+		om = append(om, KeyVal{Key: key, Val: val})
+	}
+
+	return om
+}

--- a/fixtures/format/formatted/config.json
+++ b/fixtures/format/formatted/config.json
@@ -1,38 +1,38 @@
 {
+  "language": "Numbers",
   "active": true,
   "blurb": "",
+  "ignore_pattern": "example(?!.*test)",
+  "foregone": [
+    "three",
+    "four"
+  ],
   "exercises": [
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "one",
+      "uuid": "001",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "booleans",
         "control_flow_conditionals",
         "integers",
         "logic"
-      ],
-      "unlocked_by": null,
-      "uuid": "001"
+      ]
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "two",
+      "uuid": "002",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "equality",
         "mathematics",
         "text_formatting",
         "time"
-      ],
-      "unlocked_by": null,
-      "uuid": "002"
+      ]
     }
-  ],
-  "foregone": [
-    "three",
-    "four"
-  ],
-  "ignore_pattern": "example(?!.*test)",
-  "language": "Numbers"
+  ]
 }


### PR DESCRIPTION
The ordering used is specified in
https://github.com/exercism/meta/issues/95#issuecomment-341991512

This simplifies the track-specific decisions as to whether or not
to use configlet fmt, because it now outputs config.json in an
ordering friendlier to humans than alphabetical.

For an example of a decision so simplified, see exercism/rust#516.