### PR TITLE
Comply with POSIX standards when formatting config files

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -128,6 +128,7 @@ func formatFile(path string, format formatter, order orderer) (diff string, form
 			B: difflib.SplitLines(string(formatted)),
 		})
 
+	formatted = []byte(fmt.Sprintf("%s\n", formatted))
 	return diff, formatted, err
 }
 

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,13 +20,13 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	expectedConfig = strings.TrimSuffix(string(cfg), "\n")
+	expectedConfig = string(cfg)
 
 	maintainers, err := ioutil.ReadFile(filepath.FromSlash("../fixtures/format/formatted/maintainers.json"))
 	if err != nil {
 		log.Fatal(err)
 	}
-	expectedMaintainers = strings.TrimSuffix(string(maintainers), "\n")
+	expectedMaintainers = string(maintainers)
 	result := m.Run()
 	os.Exit(result)
 }
@@ -62,4 +61,19 @@ func TestMaintainers(t *testing.T) {
 		}
 		assert.Equal(t, expectedMaintainers, string(actualMaintainers))
 	}
+}
+
+func TestNoChangeOnFormattingCompliantConfig(t *testing.T) {
+	filename := "../fixtures/format/formatted/config.json"
+	src, err := ioutil.ReadFile(filepath.FromSlash(filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, dst, err := formatFile(filepath.FromSlash(filename), formatTopics, orderConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, string(src), string(dst))
 }


### PR DESCRIPTION
Add a trailing newline to the config files when running the fmt command.

Fixes #128

@nywilken I have a separate branch where I'm refactoring this command to rely on the struct ordering rather than the OrderedMap. I want to get this fixed first though, before I rework it all.

FYI @laurafeier
(Do you recall the GitHub handle of your pair during ROSSConf by any chance?)