### PR TITLE
Distinguish between undefined and empty for topics

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -142,11 +142,14 @@ func formatTopics(m map[string]interface{}) {
 		if !ok {
 			continue
 		}
+
 		topics, ok := exercise["topics"].([]interface{})
 		if !ok {
+			// Topics are null.
 			continue
 		}
-		var sorted []string
+		// Ensure that topics are an empty list rather than null.
+		sorted := make([]string, 0)
 		for _, t := range topics {
 			topic, ok := t.(string)
 			if !ok {

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -149,7 +149,7 @@ func formatTopics(m map[string]interface{}) {
 			continue
 		}
 		// Ensure that topics are an empty list rather than null.
-		sorted := make([]string, 0)
+		sorted := make([]string, 0, len(topics))
 		for _, t := range topics {
 			topic, ok := t.(string)
 			if !ok {

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -77,3 +77,18 @@ func TestNoChangeOnFormattingCompliantConfig(t *testing.T) {
 
 	assert.Equal(t, string(src), string(dst))
 }
+func TestSemanticsOfMissingTopics(t *testing.T) {
+	// Read directly from source.
+	f := "../fixtures/format/semantics/config.json"
+	src, err := ioutil.ReadFile(filepath.FromSlash(f))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run through formatter.
+	_, dst, err := formatFile(filepath.FromSlash(f), formatTopics, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, src, dst)
+}

--- a/fixtures/format/semantics/config.json
+++ b/fixtures/format/semantics/config.json
@@ -1,0 +1,12 @@
+{
+  "exercises": [
+    {
+      "slug": "one",
+      "topics": []
+    },
+    {
+      "slug": "two",
+      "topics": null
+    }
+  ]
+}


### PR DESCRIPTION
When the maintainers have not yet considered topics for an exercise, the value should be null.
If they have decided that there are no relevant topics for an exercise, the value should be an
empty array.

Fixes #129 

FYI @laurafeier