### PR TITLE
Make checklist issue an integer

### DIFF
--- a/track/config.go
+++ b/track/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	Active         bool   `json:"active"`
 	Blurb          string `json:"blurb"`
 	Gitter         string `json:"gitter,omitempty"`
-	ChecklistIssue string `json:"checklist_issue,omitempty"`
+	ChecklistIssue int    `json:"checklist_issue,omitempty"`
 	PatternGroup
 	ForegoneSlugs   []string           `json:"foregone,omitempty"`
 	Exercises       []ExerciseMetadata `json:"exercises"`


### PR DESCRIPTION
The value is numeric; a string just doesn't make much sense here.

I've not added a test for this, since I can't see what kind of problem such a test would catch (if I had added a test for this previously, I would have assumed it was a string).

Closes #136 

We will need to fix the config in http://github.com/exercism/powershell when we cut the release for this.