### PR TITLE
Add support for optional auto-approve to exercise metadata

### DIFF
--- a/cmd/fmt_example_test.go
+++ b/cmd/fmt_example_test.go
@@ -27,41 +27,45 @@ func ExampleFormat() {
 	runFmt("../fixtures/format/unformatted/", unformattedDir, true)
 
 	// Output:
-	// -> ../fixtures/format/unformatted/config.json
+	//-> ../fixtures/format/unformatted/config.json
 	//
-	// @@ -11 +11,2 @@
-	// -{
-	// +    {
-	// +      "slug": "one",
-	// @@ -13 +13,0 @@
-	// -      "slug": "one",
-	// @@ -18,4 +18,4 @@
-	// -            "Control-flow (conditionals)",
-	// -            "Logic",
-	// -            "Booleans",
-	// -            "Integers"
-	// +        "booleans",
-	// +        "control_flow_conditionals",
-	// +        "integers",
-	// +        "logic"
-	// @@ -24,0 +25 @@
-	// +      "slug": "two",
-	// @@ -26 +26,0 @@
-	// -      "slug": "two",
-	// @@ -31,5 +31,8 @@
-	// -        "Time",
-	// -        "Mathematics",
-	// -        "Text formatting",
-	// -        "Equality"
-	// -      ]}]}
-	// +        "equality",
-	// +        "mathematics",
-	// +        "text_formatting",
-	// +        "time"
-	// +      ]
-	// +    }
-	// +  ]
-	// +}
+	//@@ -11 +11,2 @@
+	//-{
+	//+    {
+	//+      "slug": "one",
+	//@@ -13 +13,0 @@
+	//-      "slug": "one",
+	//@@ -14,0 +15 @@
+	//+      "auto_approve": true,
+	//@@ -17 +17,0 @@
+	//-      "auto_approve": true,
+	//@@ -19,4 +19,4 @@
+	//-            "Control-flow (conditionals)",
+	//-            "Logic",
+	//-            "Booleans",
+	//-            "Integers"
+	//+        "booleans",
+	//+        "control_flow_conditionals",
+	//+        "integers",
+	//+        "logic"
+	//@@ -25,0 +26 @@
+	//+      "slug": "two",
+	//@@ -27 +27,0 @@
+	//-      "slug": "two",
+	//@@ -32,5 +32,8 @@
+	//-        "Time",
+	//-        "Mathematics",
+	//-        "Text formatting",
+	//-        "Equality"
+	//-      ]}]}
+	//+        "equality",
+	//+        "mathematics",
+	//+        "text_formatting",
+	//+        "time"
+	//+      ]
+	//+    }
+	//+  ]
+	//+}
 	//
 	//-> ../fixtures/format/unformatted/config/maintainers.json
 	//
@@ -73,5 +77,5 @@ func ExampleFormat() {
 	//
 	//-> changes made to:
 	//  ../fixtures/format/unformatted/config.json
-	// ../fixtures/format/unformatted/config/maintainers.json
+	//../fixtures/format/unformatted/config/maintainers.json
 }

--- a/fixtures/format/formatted/config.json
+++ b/fixtures/format/formatted/config.json
@@ -14,6 +14,7 @@
       "slug": "one",
       "uuid": "001",
       "core": false,
+      "auto_approve": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [

--- a/fixtures/format/malformed/config.json
+++ b/fixtures/format/malformed/config.json
@@ -2,6 +2,7 @@
   "blurb": "", "active": true,
   "exercises": [ {
       "core": false,
+      "auto_approve": true,
       "difficulty": 1,
       "slug": "one",
       "topics": [ "integers", "Control-Flow    (conditionals)", "Booleans", "logic" ],

--- a/fixtures/format/semantics/config.json
+++ b/fixtures/format/semantics/config.json
@@ -7,6 +7,7 @@
       "slug": "one",
       "uuid": "1",
       "core": false,
+      "auto_approve": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": []

--- a/fixtures/format/unformatted/config.json
+++ b/fixtures/format/unformatted/config.json
@@ -14,6 +14,7 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
+      "auto_approve": true,
       "topics": [
             "Control-flow (conditionals)",
             "Logic",

--- a/track/config.go
+++ b/track/config.go
@@ -30,6 +30,7 @@ type ExerciseMetadata struct {
 	Slug         string   `json:"slug"`
 	UUID         string   `json:"uuid"`
 	IsCore       bool     `json:"core"`
+	AutoApprove  bool     `json:"auto_approve,omitempty"`
 	UnlockedBy   *string  `json:"unlocked_by"`
 	Difficulty   int      `json:"difficulty"`
 	Topics       []string `json:"topics"`


### PR DESCRIPTION
We've currently made any hello-world exercises auto-approved in the backend of v2. This means that you don't need mentor approval in order to move forward when you've completed that exercise.

Not all tracks have a hello-world, and some tracks might want to auto approve other (or additional) exercises.

This adds a boolean to the `ExerciseMetadata`, which will only be formatted if present.

Closes #137