### PR TITLE
scripts: add fetch-configlet scripts for Unix and Windows

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+LATEST=https://github.com/exercism/configlet/releases/latest
+
+OS=$(
+case $(uname) in
+    (Darwin*)
+        echo "mac";;
+    (Linux*)
+        echo "linux";;
+    (*)
+        echo "linux";;
+esac)
+ARCH=$(
+case $(uname -m) in
+    (*64*)
+        echo 64bit;;
+    (*686*)
+        echo 32bit;;
+    (*386*)
+        echo 32bit;;
+    (*)
+        echo 64bit;;
+esac)
+VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+curl -s --location $URL | tar xz -C bin/

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -1,0 +1,30 @@
+Function RedirectLocationHeader([string]$url) {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+    $latest = "https://github.com/exercism/configlet/releases/latest"
+    $request = [System.Net.WebRequest]::Create($latest)
+    $request.AllowAutoRedirect = $false
+    $response = $request.GetResponse()
+
+    $response.GetResponseHeader("Location")
+}
+
+Function LatestVersion {
+    $location = RedirectLocationHeader("https://github.com/exercism/configlet/releases/latest")
+    $location.Substring($location.LastIndexOf("/") + 1)
+}
+
+Function Arch {
+    If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
+}
+
+$arch = Arch
+$version = LatestVersion
+$fileName = "configlet-windows-$arch.zip"
+$url = "https://github.com/exercism/configlet/releases/download/$version/$filename"
+$outputDirectory = "bin"
+$outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
+
+Invoke-WebRequest -Uri $url -OutFile $outputFile
+Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
+Remove-Item -Path $outputFile


### PR DESCRIPTION
Many repositories have a `fetch-configlet` script in their `bin` folder, but as far as I can tell no such file is maintained in this repository. To me, this goes against the principle of least surprise, so this PR adds that script in this repository. I've also created a version of the fetch-configlet script that runs on Windows (which uses PowerShell). The original `fetch-configlet` script made it seem like it also supported Windows, but it did not work on Windows.

I'm not entirely sure this is the right place for this PR. Let me know if it's not.