### PR TITLE
Fix fetch-configlet bash script for windows

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -8,9 +8,22 @@ case $(uname) in
         echo "mac";;
     (Linux*)
         echo "linux";;
+    (Windows*)
+        echo "windows";;
+    (MINGW*)
+        echo "windows";;
     (*)
         echo "linux";;
 esac)
+
+EXT=$(
+case $OS in
+    (windows*)
+        echo "zip";;
+    (*)
+        echo "tgz";;
+esac)
+
 ARCH=$(
 case $(uname -m) in
     (*64*)
@@ -22,6 +35,16 @@ case $(uname -m) in
     (*)
         echo 64bit;;
 esac)
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
-curl -s --location $URL | tar xz -C bin/
+
+
+VERSION="$(curl --silent --head $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.$EXT
+
+case $EXT in
+    (*zip)
+        curl -s --location $URL -o bin/latest-configlet.zip
+        unzip bin/latest-configlet.zip -d bin/
+        rm bin/latest-configlet.zip;;
+    (*)
+        curl -s --location $URL | tar xz -C bin/;;
+esac


### PR DESCRIPTION
* This correctly sets the OS and EXTension when on windows, even when in bash (or a different bourne-shell). 

* Additionally this uses unzip if the extension is zip, as tar will correctly say the zip is not a tar. 
  `unzip` does not allow for piping, so a temporary file is created.