### PR TITLE
Update copyright in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Exercism, Inc
+Copyright (c) 2019 Exercism
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This ensures that the year is up to date, and
that the copyright is assigned to the not-for-profit
Exercism, rather than the (now-defunct) Delaware
Corporation that we had in place as a temporary
measure for legal protection until we could
figure out how to structure things properly.

Also, some very old repos still listed me
as the copyright holder. I'm assigning
all copyright to Exercism, even for those
old repos.

Ref: https://github.com/exercism/exercism/issues/4823