### PR TITLE
fetch-configlet.sh: Fetch the latest release url from the Github API

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -37,8 +37,7 @@ case $(uname -m) in
 esac)
 
 
-VERSION="$(curl --silent --head $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.$EXT
+URL=$(curl -s https://api.github.com/repos/exercism/configlet/releases/latest | awk "/browser_download/ && /$OS-$ARCH.$EXT/" | cut -d : -f 2,3 | tr -d \")
 
 case $EXT in
     (*zip)


### PR DESCRIPTION
This PR changes the approach the URL for the latest release of `configlet` is built.
Before the PR: Manually build the URL using the version from the HTTP header.
After the PR: Get the full URL from the [Github API](https://developer.github.com/v3/repos/releases/#get-the-latest-release). IMHO this approach is more reliable. 