### PR TITLE
Allow a DO_NOT_IMPLEMENT.md file in foregone exercises

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -270,7 +270,7 @@ func foregoneViolations(t track.Track) []string {
 
 	slugs := []string{}
 	for _, exercise := range t.Exercises {
-		if violations[exercise.Slug] {
+		if violations[exercise.Slug] && !exercise.IsDoNotImplementOnly() {
 			slugs = append(slugs, exercise.Slug)
 		}
 	}

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -224,7 +224,7 @@ func TestForegoneViolationWithDoNotImplementOnly(t *testing.T) {
 	slugs := foregoneViolations(track)
 
 	if len(slugs) != 0 {
-		t.Fatalf("Expected no foregone violations in 0 exercises, but found violations: %s", string(slugs))
+		t.Fatalf("Expected no foregone violations in 0 exercises, but found violations: %v", string(slugs))
 	}
 }
 

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -224,7 +224,7 @@ func TestForegoneViolationWithDoNotImplementOnly(t *testing.T) {
 	slugs := foregoneViolations(track)
 
 	if len(slugs) != 0 {
-		t.Fatalf("Expected no foregone violations in 0 exercises, but found violations: %v", string(slugs))
+		t.Fatalf("Expected no foregone violations in 0 exercises, but found violations: %v", slugs)
 	}
 }
 

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -210,6 +210,24 @@ func TestForegoneViolations(t *testing.T) {
 	assert.Equal(t, "cherry", slugs[1])
 }
 
+func TestForegoneViolationWithDoNotImplementOnly(t *testing.T) {
+	track := track.Track{
+		Config: track.Config{
+			ForegoneSlugs: []string{"banana"},
+		},
+		Exercises: []track.Exercise{
+			{Slug: "apple"},
+			{Slug: "banana", DoNotImplementPath: "DO_NOT_IMPLEMENT.md"},
+		},
+	}
+
+	slugs := foregoneViolations(track)
+
+	if len(slugs) != 0 {
+		t.Fatalf("Expected no foregone violations in 0 exercises, but found violations: %s", string(slugs))
+	}
+}
+
 func TestDuplicateSlugs(t *testing.T) {
 	track := track.Track{
 		Config: track.Config{

--- a/fixtures/lint/valid-track/config.json
+++ b/fixtures/lint/valid-track/config.json
@@ -13,5 +13,5 @@
       "difficulty": 1
     }
   ],
-  "foregone": []
+  "foregone": ["do-not-implement"]
 }

--- a/track/exercise.go
+++ b/track/exercise.go
@@ -10,10 +10,11 @@ import (
 
 // Exercise is an implementation of an Exercism exercise.
 type Exercise struct {
-	Slug          string
-	ReadmePath    string
-	SolutionPath  string
-	TestSuitePath string
+	Slug               string
+	ReadmePath         string
+	SolutionPath       string
+	TestSuitePath      string
+	DoNotImplementPath string
 }
 
 // NewExercise loads an exercise.
@@ -33,6 +34,11 @@ func NewExercise(root string, pg PatternGroup) (Exercise, error) {
 	}
 
 	err = setPath(root, "README\\.md", &ex.ReadmePath)
+	if err != nil {
+		return ex, err
+	}
+
+	err = setPath(root, "DO_NOT_IMPLEMENT\\.md", &ex.DoNotImplementPath)
 	return ex, err
 }
 
@@ -77,4 +83,12 @@ func (ex Exercise) HasTestSuite() bool {
 // IsValid checks that an exercise has a sample solution.
 func (ex Exercise) IsValid() bool {
 	return ex.SolutionPath != ""
+}
+
+// IsDoNotImplementOnly checks that an exercise only has a DO_NOT_IMPLEMENT.md file.
+func (ex Exercise) IsDoNotImplementOnly() bool {
+	return ex.ReadmePath == ""
+		&& ex.TestSuitePath == ""
+		&& ex.SolutionPath == ""
+		&& ex.DoNotImplementPath != ""
 }

--- a/track/exercise.go
+++ b/track/exercise.go
@@ -87,8 +87,8 @@ func (ex Exercise) IsValid() bool {
 
 // IsDoNotImplementOnly checks that an exercise only has a DO_NOT_IMPLEMENT.md file.
 func (ex Exercise) IsDoNotImplementOnly() bool {
-	return ex.ReadmePath == ""
-		&& ex.TestSuitePath == ""
-		&& ex.SolutionPath == ""
-		&& ex.DoNotImplementPath != ""
+	return ex.ReadmePath == "" &&
+		ex.TestSuitePath == "" &&
+		ex.SolutionPath == "" &&
+		ex.DoNotImplementPath != ""
 }


### PR DESCRIPTION
Modify the configlet code to allow use-cases like https://github.com/exercism/java/pull/1711. Basically, by allowing this one file in the stub directory, we can make it clearer if there are reasons (for example, a license problem) that we cannot implement the exercise. The markdown file would also allow us to explain why the exercise cannot be implemented in this track.