### PR TITLE
scripts: Add MSYS_NT-* => Windows OS selection

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -10,11 +10,12 @@ get_version () {
 }
 
 case "$(uname)" in
-    (Darwin*)  OS='mac'     ;;
-    (Linux*)   OS='linux'   ;;
-    (Windows*) OS='windows' ;;
-    (MINGW*)   OS='windows' ;;
-    (*)        OS='linux'   ;;
+    (Darwin*)   OS='mac'     ;;
+    (Linux*)    OS='linux'   ;;
+    (Windows*)  OS='windows' ;;
+    (MINGW*)    OS='windows' ;;
+    (MSYS_NT-*) OS='windows' ;;
+    (*)         OS='linux'   ;;
 esac
 
 case "$OS" in


### PR DESCRIPTION
Travis' Windows environment uses Git Bash, with the `uname` `MSYS_NT-10.0`.

See https://travis-ci.org/exercism/julia/jobs/568120982 and https://github.com/exercism/julia/commit/ec92ee2d7fcf8ac674be80e4f64b89463ce15eee for "proof" that it works, since scripts aren't tested by CI in this repo.