### PR TITLE
fetch-configlet: set pipefail shell option

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 LATEST=https://github.com/exercism/configlet/releases/latest
 
 OS=$(


### PR DESCRIPTION
So here it is with the `pipefail` option set.

I usually stay away from the `errexit` option, but it occurs to me that it could be beneficial in this case.
If we also set the the `errexit` option then I believe this script will exit with an appropriate error message even if the subprocess from the command substitution in the assignment to `VERSION` fails.  This does seem like the best behavior.

Therefore, please let me know if there is agreement that `errexit` should also be set :smile:

PS. I have a style concern about the terminators in the case statements.  This is outside of this PR's scope, but after this is merged I will open a PR that presents changes to the case style (specifically to make it conform more closely to some of the most accepted Bash style guides on the web ;) )