### PR TITLE
fetch-configlet: style refactoring

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -1,52 +1,43 @@
 #!/bin/bash
 
-set -o pipefail
+set -eo pipefail
 
-LATEST=https://github.com/exercism/configlet/releases/latest
+readonly RELEASES='https://github.com/exercism/configlet/releases'
 
-OS=$(
-case $(uname) in
-    (Darwin*)
-        echo "mac";;
-    (Linux*)
-        echo "linux";;
-    (Windows*)
-        echo "windows";;
-    (MINGW*)
-        echo "windows";;
-    (*)
-        echo "linux";;
-esac)
+get_version () {
+    curl --silent --head ${RELEASES}/latest  |
+        awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r'
+}
 
-EXT=$(
-case $OS in
-    (windows*)
-        echo "zip";;
-    (*)
-        echo "tgz";;
-esac)
+case "$(uname)" in
+    (Darwin*)  OS='mac'     ;;
+    (Linux*)   OS='linux'   ;;
+    (Windows*) OS='windows' ;;
+    (MINGW*)   OS='windows' ;;
+    (*)        OS='linux'   ;;
+esac
 
-ARCH=$(
-case $(uname -m) in
-    (*64*)
-        echo 64bit;;
-    (*686*)
-        echo 32bit;;
-    (*386*)
-        echo 32bit;;
-    (*)
-        echo 64bit;;
-esac)
+case "$OS" in
+    (windows*) EXT='zip' ;;
+    (*)        EXT='tgz' ;;
+esac
+
+case "$(uname -m)" in
+    (*64*)  ARCH='64bit' ;;
+    (*686*) ARCH='32bit' ;;
+    (*386*) ARCH='32bit' ;;
+    (*)     ARCH='64bit' ;;
+esac
 
 
-VERSION="$(curl --silent --head $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.$EXT
+VERSION="$(get_version)"
+URL="${RELEASES}/download/${VERSION}/configlet-${OS}-${ARCH}.${EXT}"
 
-case $EXT in
+case "$EXT" in
     (*zip)
-        curl -s --location $URL -o bin/latest-configlet.zip
+        curl -s --location "$URL" -o bin/latest-configlet.zip
         unzip bin/latest-configlet.zip -d bin/
-        rm bin/latest-configlet.zip;;
-    (*)
-        curl -s --location $URL | tar xz -C bin/;;
+        rm bin/latest-configlet.zip
+        ;;
+    (*) curl -s --location "$URL" | tar xz -C bin/ ;;
 esac


### PR DESCRIPTION
1. Reduced unnecessary command substitution wrappers around case statements for variable assignment.  It is safer this way.
2. Used appropriate quoting everywhere. This wasn't necessary everywhere, but the consistency is nice (and it doesn't hurt anything.
3. moving the assignment pipe-chain for `VERSION` into a function makes the actual substitution assignment to `VERSION` much cleaner.
4. Good rules for `case` include:
    - single line cases must have 1 space to either side (between pattern and `;;`). I aligned them for readability too ;)
    - multi-line cases start indented on next line and `;;` comes on its own line. (some people argue that it should be at the same indent level as the patterns, but I think it looks much nicer the way it is now ;) )
5. Finally, renamed `LATEST` to `RELEASES` (just one level higher in the path hierarchy), so it could be reused to save line space.  Now all lines are under 80 characters :tada: 

EDIT: I also added `-e` to the `set` options at the head of the script. This will make it exit on any error without continuing.  Hopefully it helps make things clearer when Travis fails.
