### PR TITLE
lint: Check that UUIDs are valid

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/exercism/configlet/track"
 	"github.com/exercism/configlet/ui"
 	"github.com/spf13/cobra"
@@ -104,6 +105,10 @@ func lintTrack(path string) bool {
 		{
 			check: missingUUID,
 			msg:   "The exercise '%v' was found in config.json, but does not have a UUID.",
+		},
+		{
+			check: invalidUUID,
+			msg:   "The exercise '%v' has an invalid UUID in config.json.",
 		},
 		{
 			check: foregoneViolations,
@@ -255,6 +260,17 @@ func missingUUID(t track.Track) []string {
 	slugs := []string{}
 	for _, exercise := range t.Config.Exercises {
 		if exercise.UUID == "" {
+			slugs = append(slugs, exercise.Slug)
+		}
+	}
+
+	return slugs
+}
+
+func invalidUUID(t track.Track) []string {
+	slugs := []string{}
+	for _, exercise := range t.Config.Exercises {
+		if _, err := uuid.Parse(exercise.UUID); err != nil {
 			slugs = append(slugs, exercise.Slug)
 		}
 	}

--- a/cmd/lint_example_test.go
+++ b/cmd/lint_example_test.go
@@ -19,6 +19,8 @@ func ExampleLint() {
 	// -> The implementation for 'three' is missing an example solution.
 	// -> The implementation for 'two' is missing a test suite.
 	// -> The exercise 'one' was found in config.json, but does not have a UUID.
+	// -> The exercise 'one' has an invalid UUID in config.json.
+	// -> The exercise 'three' has an invalid UUID in config.json.
 	// -> An implementation for 'zero' was found, but config.json specifies that it should be foregone (not implemented).
 }
 

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -235,6 +235,40 @@ func TestDuplicateSlugs(t *testing.T) {
 	assert.Equal(t, "banana", slugs[1])
 }
 
+func TestInvalidUUID(t *testing.T) {
+	uuidTests := []struct {
+		desc     string
+		expected []string
+		config   track.Config
+	}{
+		{
+			desc:     "should approve a good UUID",
+			expected: []string{},
+			config: track.Config{
+				Exercises: []track.ExerciseMetadata{
+					{Slug: "apple", UUID: "123e4567-e89b-12d3-a456-111111111111"},
+				},
+			},
+		},
+		{
+			desc:     "should disapprove a bad UUID",
+			expected: []string{"banana"},
+			config: track.Config{
+				Exercises: []track.ExerciseMetadata{
+					{Slug: "banana", UUID: "123e4567-e89b-12d3-a456-gggggggggggg"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range uuidTests {
+		track := track.Track{Config: tt.config}
+		uuids := invalidUUID(track)
+
+		assert.ElementsMatch(t, tt.expected, uuids, tt.desc)
+	}
+}
+
 func TestDuplicateUUID(t *testing.T) {
 	uuidTests := []struct {
 		desc     string

--- a/fixtures/lint/valid-track/config.json
+++ b/fixtures/lint/valid-track/config.json
@@ -7,7 +7,7 @@
   "test_pattern": "(?i)test",
   "exercises": [
     {
-      "uuid": "aaa",
+      "uuid": "123e4567-e89b-12d3-a456-111111111111",
       "slug": "aluminum",
       "topics": [],
       "difficulty": 1

--- a/fixtures/missing-readme/config.json
+++ b/fixtures/missing-readme/config.json
@@ -5,7 +5,7 @@
   "active": true,
   "exercises": [
     {
-      "uuid": "missingmissing",
+      "uuid": "123e4567-e89b-12d3-a456-111111111111",
       "slug": "missing-readme",
       "topics": [],
       "difficulty": 1

--- a/fixtures/numbers/config.json
+++ b/fixtures/numbers/config.json
@@ -11,20 +11,20 @@
       "difficulty": 1
     },
     {
-      "uuid": "bbb",
+      "uuid": "123e4567-e89b-12d3-a456-111111111111",
       "slug": "two",
       "deprecated": true,
       "topics": [],
       "difficulty": 1
     },
     {
-      "uuid": "ccc",
+      "uuid": "invalid",
       "slug": "three",
       "topics": [],
       "difficulty": 1
     },
     {
-      "uuid": "ddd",
+      "uuid": "123e4567-e89b-12d3-a456-222222222222",
       "slug": "bajillion",
       "topics": [],
       "difficulty": 1


### PR DESCRIPTION
all tests that involve lint are hereby updated to do one of the two:
1. have valid UUIDs
2. keep their invalid UUIDs, and expect that an error for them is shown.

Closes https://github.com/exercism/configlet/issues/99