### PR TITLE
Update scripts to support authentication

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-readonly RELEASES='https://api.github.com/repos/exercism/configlet/releases/latest'
+readonly LATEST='https://api.github.com/repos/exercism/configlet/releases/latest'
 
 case "$(uname)" in
     (Darwin*)   OS='mac'     ;;

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -2,12 +2,7 @@
 
 set -eo pipefail
 
-readonly RELEASES='https://github.com/exercism/configlet/releases'
-
-get_version () {
-    curl --silent --head ${RELEASES}/latest  |
-        awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r'
-}
+readonly RELEASES='https://api.github.com/repos/exercism/configlet/releases/latest'
 
 case "$(uname)" in
     (Darwin*)   OS='mac'     ;;
@@ -30,15 +25,28 @@ case "$(uname -m)" in
     (*)     ARCH='64bit' ;;
 esac
 
+if [ -z "${GITHUB_TOKEN}" ]
+then
+    HEADER=''
+else
+    HEADER="authorization: Bearer ${GITHUB_TOKEN}"
+fi
 
-VERSION="$(get_version)"
-URL="${RELEASES}/download/${VERSION}/configlet-${OS}-${ARCH}.${EXT}"
+FILENAME="configlet-${OS}-${ARCH}.${EXT}"
+
+get_url () {
+    curl --header $HEADER -s $RELEASES |
+        awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
+        tr -d '"'
+}
+
+URL=$(get_url)
 
 case "$EXT" in
     (*zip)
-        curl -s --location "$URL" -o bin/latest-configlet.zip
+        curl --header $HEADER -s --location "$URL" -o bin/latest-configlet.zip
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;
-    (*) curl -s --location "$URL" | tar xz -C bin/ ;;
+    (*) curl --header $HEADER -s --location "$URL" | tar xz -C bin/ ;;
 esac

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -44,7 +44,7 @@ URL=$(get_url)
 
 case "$EXT" in
     (*zip)
-        curl --header $HEADER -s --location "$URL" -o bin/latest-configlet.zip
+        curl --header "$HEADER" -s --location "$URL" -o bin/latest-configlet.zip
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -48,5 +48,5 @@ case "$EXT" in
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;
-    (*) curl --header $HEADER -s --location "$URL" | tar xz -C bin/ ;;
+    (*) curl --header "$HEADER" -s --location "$URL" | tar xz -C bin/ ;;
 esac

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -35,7 +35,7 @@ fi
 FILENAME="configlet-${OS}-${ARCH}.${EXT}"
 
 get_url () {
-    curl --header $HEADER -s $RELEASES |
+    curl --header "$HEADER" -s "$LATEST" |
         awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
         tr -d '"'
 }

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -1,17 +1,11 @@
-Function RedirectLocationHeader([string]$url) {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
-    $latest = "https://github.com/exercism/configlet/releases/latest"
-    $request = [System.Net.WebRequest]::Create($latest)
-    $request.AllowAutoRedirect = $false
-    $response = $request.GetResponse()
-
-    $response.GetResponseHeader("Location")
+Function DownloadUrl ([string] $FileName, $Headers) {
+    $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
+    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl
+    $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
 }
 
-Function LatestVersion {
-    $location = RedirectLocationHeader("https://github.com/exercism/configlet/releases/latest")
-    $location.Substring($location.LastIndexOf("/") + 1)
+Function Headers {
+    If ($GITHUB_TOKEN) { @{ Authorization = "Bearer ${GITHUB_TOKEN}" } } Else { @{ } }
 }
 
 Function Arch {
@@ -19,12 +13,12 @@ Function Arch {
 }
 
 $arch = Arch
-$version = LatestVersion
+$headers = Headers
 $fileName = "configlet-windows-$arch.zip"
-$url = "https://github.com/exercism/configlet/releases/download/$version/$filename"
 $outputDirectory = "bin"
 $outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
+$zipUrl = DownloadUrl -FileName $fileName -Headers $headers
 
-Invoke-WebRequest -Uri $url -OutFile $outputFile
+Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile
 Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
 Remove-Item -Path $outputFile


### PR DESCRIPTION
In issue #173, an issue was reported that reported that some runs of the `fetch-configlet` script led to the following error: "stdin: not in gzip format." As it turned out, this was due to the `fetch-configlet` script sometimes not being able to download the `configlet` binary, which is very likely due to rate limiting issues.

To work around this issue, this PR adds support for adding an authentication bearer token, which will increase the rate limit. It does this by checking for the presence of an environment variable named `GITHUB_TOKEN`. If such an environment variable is found, the authentication header is sent. Otherwise, a normal, unauthenticated request is made.

This issue will usually pop-up in CI scenarios, where the `configlet` script is fetched for each CI run. In the case when Github Actions is used as the CI, using this updated version of the `fetch-configlet` script is simple: simply update the contents of the `fetch-configlet` file to the one in this PR and add the following line to your GH Action workflow: https://github.com/exercism/csharp/pull/1375/files#diff-fe8421955fd596131bb6f1b78984b2fbR15 This will ensure that the automatically provided secret Github token value is passed along to the script.

If tracks use a different CI system, we'd have to create a token and then store that as a secret in the repositories. Let us know if you want to do this.