### PR TITLE
[fetch-configlet] make more portable

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 


### PR DESCRIPTION
This makes the `fetch-configlet` script more portable by using `/usr/bin/env bash` as the interpreter for the file.

`/usr/bin/env` and its location are defined by POSIX, while `/bin/bash` is not, and different systems might have `bash` at different locations.

Aside of that, even nixOS which does not follow POSIX rules and conventions, does provide `/usr/bin/env` by default, while making `bash` available at `/bin/bash` or any other (for nixOS) non-default location would require messing around with the system in ways that are considered a flaw within the nixOS community as they introduce impurities.