### PR TITLE
[CI] update go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: go
 sudo: false
 
 go:
-  - 1.8
-  - 1.9
+  - 1.14
+  - 1.15
   - tip
 
 install: true


### PR DESCRIPTION
Bump the used golang versions to the 2 most recent releases.

This seems to be necessary, as #177 fails to build as the source code of the configlet uses some features that are not available in the foremerly used 1.8 and 1.9 of go.